### PR TITLE
Use application Label, not name when listing app resources

### DIFF
--- a/pkg/connector/app.go
+++ b/pkg/connector/app.go
@@ -295,7 +295,7 @@ func appResource(ctx context.Context, app *okta.Application) (*v2.Resource, erro
 
 	return &v2.Resource{
 		Id:          fmtResourceId(resourceTypeApp.Id, app.Id),
-		DisplayName: app.Name,
+		DisplayName: app.Label,
 		Annotations: annos,
 	}, nil
 }


### PR DESCRIPTION
Application name gives us the type of app, not the display name.