### PR TITLE
Fetch all users. By default, Okta's ListUsers doesn't return deactivated users.

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -106,6 +106,9 @@ func userName(user *okta.User) (string, string) {
 }
 
 func listUsers(ctx context.Context, client *okta.Client, token *pagination.Token, qp *query.Params) ([]*okta.User, *responseContext, error) {
+	if qp.Search != "" {
+		qp.Search = "status pr" // ListUsers doesn't get deactivated users by default. this should fetch them all
+	}
 	oktaUsers, resp, err := client.User.ListUsers(ctx, qp)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
I tested this with a deactivated user. The old code doesn't sync that user. This code does.