### PR TITLE
Make entitlement names unique

### DIFF
--- a/pkg/connector/app.go
+++ b/pkg/connector/app.go
@@ -341,12 +341,12 @@ func appEntitlement(ctx context.Context, resource *v2.Resource, permission strin
 	return &v2.Entitlement{
 		Id:          fmtResourceRole(resource.Id, permission),
 		Resource:    resource,
-		DisplayName: fmt.Sprintf("%s app access", resource.DisplayName),
-		Description: fmt.Sprintf("Has access to the %s app in Okta", resource.DisplayName),
+		DisplayName: fmt.Sprintf("%s App %s", resource.DisplayName, permission),
+		Description: fmt.Sprintf("Can %s on Okta app %s", permission, resource.DisplayName),
 		Annotations: annos,
 		GrantableTo: []*v2.ResourceType{resourceTypeGroup, resourceTypeUser},
 		Purpose:     v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
-		Slug:        resource.DisplayName,
+		Slug:        fmt.Sprintf("%s - %s", resource.DisplayName, permission),
 	}
 }
 

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -311,12 +311,12 @@ func (o *groupResourceType) groupEntitlement(ctx context.Context, resource *v2.R
 	return &v2.Entitlement{
 		Id:          fmtResourceRole(resource.Id, permission),
 		Resource:    resource,
-		DisplayName: fmt.Sprintf("%s Group Member", resource.DisplayName),
-		Description: fmt.Sprintf("Member of %s group in Okta", resource.DisplayName),
+		DisplayName: fmt.Sprintf("%s Group %s", resource.DisplayName, permission),
+		Description: fmt.Sprintf("%s in Okta group %s", permission, resource.DisplayName),
 		Annotations: annos,
 		GrantableTo: []*v2.ResourceType{resourceTypeUser},
 		Purpose:     v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
-		Slug:        resource.DisplayName,
+		Slug:        fmt.Sprintf("%s - %s", resource.DisplayName, permission),
 	}
 }
 


### PR DESCRIPTION
We should probably pass the whole role into these functions so we can use both the type and the label, but this is better than the previous naming.