### PR TITLE
Add response cache options to okta connector. Default to on.

### DIFF
--- a/cmd/baton-okta/config.go
+++ b/cmd/baton-okta/config.go
@@ -15,6 +15,9 @@ var (
 	ciam               = field.BoolField("ciam", field.WithDescription("Whether to run in CIAM mode or not. In CIAM mode, only roles and the users assigned to roles are synced"))
 	ciamEmailDomains   = field.StringSliceField("ciam-email-domains",
 		field.WithDescription("The email domains to use for CIAM mode. Any users that don't have an email address with one of the provided domains will be ignored, unless explicitly granted a role"))
+	cache    = field.BoolField("cache", field.WithDescription("Enable response cache"), field.WithDefaultValue(true))
+	cacheTti = field.IntField("cache-tti", field.WithDescription("Response cache cleanup interval in seconds"), field.WithDefaultValue(60))
+	cacheTtl = field.IntField("cache-ttl", field.WithDescription("Response cache time to live in seconds"), field.WithDefaultValue(300))
 )
 
 var relationships = []field.SchemaFieldRelationship{
@@ -24,6 +27,16 @@ var relationships = []field.SchemaFieldRelationship{
 }
 
 var configuration = field.NewConfiguration([]field.SchemaField{
-	domain, apiToken, oktaClientId, oktaPrivateKey, oktaPrivateKeyId,
-	syncInactivateApps, oktaProvisioning, ciam, ciamEmailDomains,
+	domain,
+	apiToken,
+	oktaClientId,
+	oktaPrivateKey,
+	oktaPrivateKeyId,
+	syncInactivateApps,
+	oktaProvisioning,
+	ciam,
+	ciamEmailDomains,
+	cache,
+	cacheTti,
+	cacheTtl,
 }, relationships...)

--- a/cmd/baton-okta/config.go
+++ b/cmd/baton-okta/config.go
@@ -16,8 +16,8 @@ var (
 	ciamEmailDomains   = field.StringSliceField("ciam-email-domains",
 		field.WithDescription("The email domains to use for CIAM mode. Any users that don't have an email address with one of the provided domains will be ignored, unless explicitly granted a role"))
 	cache    = field.BoolField("cache", field.WithDescription("Enable response cache"), field.WithDefaultValue(true))
-	cacheTti = field.IntField("cache-tti", field.WithDescription("Response cache cleanup interval in seconds"), field.WithDefaultValue(60))
-	cacheTtl = field.IntField("cache-ttl", field.WithDescription("Response cache time to live in seconds"), field.WithDefaultValue(300))
+	cacheTTI = field.IntField("cache-tti", field.WithDescription("Response cache cleanup interval in seconds"), field.WithDefaultValue(60))
+	cacheTTL = field.IntField("cache-ttl", field.WithDescription("Response cache time to live in seconds"), field.WithDefaultValue(300))
 )
 
 var relationships = []field.SchemaFieldRelationship{
@@ -37,6 +37,6 @@ var configuration = field.NewConfiguration([]field.SchemaField{
 	ciam,
 	ciamEmailDomains,
 	cache,
-	cacheTti,
-	cacheTtl,
+	cacheTTI,
+	cacheTTL,
 }, relationships...)

--- a/cmd/baton-okta/main.go
+++ b/cmd/baton-okta/main.go
@@ -49,8 +49,8 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		Ciam:             v.GetBool("ciam"),
 		CiamEmailDomains: v.GetStringSlice("ciam-email-domains"),
 		Cache:            v.GetBool("cache"),
-		CacheTti:         v.GetInt32("cache-tti"),
-		CacheTtl:         v.GetInt32("cache-ttl"),
+		CacheTTI:         v.GetInt32("cache-tti"),
+		CacheTTL:         v.GetInt32("cache-ttl"),
 	}
 
 	cb, err := connector.New(ctx, ccfg)

--- a/cmd/baton-okta/main.go
+++ b/cmd/baton-okta/main.go
@@ -48,6 +48,9 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		OktaProvisioning: v.GetBool("okta-provisioning"),
 		Ciam:             v.GetBool("ciam"),
 		CiamEmailDomains: v.GetStringSlice("ciam-email-domains"),
+		Cache:            v.GetBool("cache"),
+		CacheTti:         v.GetInt32("cache-tti"),
+		CacheTtl:         v.GetInt32("cache-ttl"),
 	}
 
 	cb, err := connector.New(ctx, ccfg)

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -38,8 +38,8 @@ type Config struct {
 	Ciam             bool
 	CiamEmailDomains []string
 	Cache            bool
-	CacheTti         int32
-	CacheTtl         int32
+	CacheTTI         int32
+	CacheTTL         int32
 }
 
 func v1AnnotationsForResourceType(resourceTypeID string, skipEntitlementsAndGrants bool) annotations.Annotations {
@@ -181,8 +181,8 @@ func New(ctx context.Context, cfg *Config) (*Okta, error) {
 			okta.WithToken(cfg.ApiToken),
 			okta.WithHttpClientPtr(client),
 			okta.WithCache(cfg.Cache),
-			okta.WithCacheTti(cfg.CacheTti),
-			okta.WithCacheTtl(cfg.CacheTtl),
+			okta.WithCacheTti(cfg.CacheTTI),
+			okta.WithCacheTtl(cfg.CacheTTL),
 		)
 		if err != nil {
 			return nil, err
@@ -201,8 +201,8 @@ func New(ctx context.Context, cfg *Config) (*Okta, error) {
 			okta.WithPrivateKey(cfg.OktaPrivateKey),
 			okta.WithPrivateKeyId(cfg.OktaPrivateKeyId),
 			okta.WithCache(cfg.Cache),
-			okta.WithCacheTti(cfg.CacheTti),
-			okta.WithCacheTtl(cfg.CacheTtl),
+			okta.WithCacheTti(cfg.CacheTTI),
+			okta.WithCacheTtl(cfg.CacheTTL),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -37,6 +37,9 @@ type Config struct {
 	OktaProvisioning bool
 	Ciam             bool
 	CiamEmailDomains []string
+	Cache            bool
+	CacheTti         int32
+	CacheTtl         int32
 }
 
 func v1AnnotationsForResourceType(resourceTypeID string, skipEntitlementsAndGrants bool) annotations.Annotations {
@@ -177,7 +180,9 @@ func New(ctx context.Context, cfg *Config) (*Okta, error) {
 			okta.WithOrgUrl(fmt.Sprintf("https://%s", cfg.Domain)),
 			okta.WithToken(cfg.ApiToken),
 			okta.WithHttpClientPtr(client),
-			okta.WithCache(false),
+			okta.WithCache(cfg.Cache),
+			okta.WithCacheTti(cfg.CacheTti),
+			okta.WithCacheTtl(cfg.CacheTtl),
 		)
 		if err != nil {
 			return nil, err
@@ -195,7 +200,9 @@ func New(ctx context.Context, cfg *Config) (*Okta, error) {
 			okta.WithScopes(scopes),
 			okta.WithPrivateKey(cfg.OktaPrivateKey),
 			okta.WithPrivateKeyId(cfg.OktaPrivateKeyId),
-			okta.WithCache(false),
+			okta.WithCache(cfg.Cache),
+			okta.WithCacheTti(cfg.CacheTti),
+			okta.WithCacheTtl(cfg.CacheTtl),
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
It looks like the okta client has its own cache options. We might as well use that.