### PR TITLE
Only get assigned users for aws mode (when group mapping not enabled)

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -184,14 +184,14 @@ var (
 func (o *Okta) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
 	if o.ciamConfig.Enabled {
 		return []connectorbuilder.ResourceSyncer{
-			ciamUserBuilder(o.domain, o.apiToken, o.client, o.ciamConfig.EmailDomains, o.skipSecondaryEmails),
+			ciamUserBuilder(o),
 			ciamBuilder(o.client, o.skipSecondaryEmails),
 		}
 	}
 
 	if o.awsConfig.Enabled {
 		return []connectorbuilder.ResourceSyncer{
-			userBuilder(o.domain, o.apiToken, o.client, o.skipSecondaryEmails, o),
+			userBuilder(o),
 			groupBuilder(o),
 			accountBuilder(o),
 		}
@@ -199,7 +199,7 @@ func (o *Okta) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceS
 
 	resourceSyncer := []connectorbuilder.ResourceSyncer{
 		roleBuilder(o.client, o),
-		userBuilder(o.domain, o.apiToken, o.client, o.skipSecondaryEmails, o),
+		userBuilder(o),
 		groupBuilder(o),
 		appBuilder(o.domain, o.apiToken, o.syncInactiveApps, o.client),
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -191,7 +191,7 @@ func (o *Okta) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceS
 
 	if o.awsConfig.Enabled {
 		return []connectorbuilder.ResourceSyncer{
-			userBuilder(o.domain, o.apiToken, o.client, o.skipSecondaryEmails),
+			userBuilder(o.domain, o.apiToken, o.client, o.skipSecondaryEmails, o),
 			groupBuilder(o),
 			accountBuilder(o),
 		}
@@ -199,7 +199,7 @@ func (o *Okta) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceS
 
 	resourceSyncer := []connectorbuilder.ResourceSyncer{
 		roleBuilder(o.client, o),
-		userBuilder(o.domain, o.apiToken, o.client, o.skipSecondaryEmails),
+		userBuilder(o.domain, o.apiToken, o.client, o.skipSecondaryEmails, o),
 		groupBuilder(o),
 		appBuilder(o.domain, o.apiToken, o.syncInactiveApps, o.client),
 	}

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -125,9 +125,11 @@ func (o *groupResourceType) Grants(
 	}
 
 	if bag.Current() == nil {
-		bag.Push(pagination.PageState{
-			ResourceTypeID: resourceTypeRole.Id,
-		})
+		if o.connector.awsConfig == nil || !o.connector.awsConfig.Enabled {
+			bag.Push(pagination.PageState{
+				ResourceTypeID: resourceTypeRole.Id,
+			})
+		}
 		bag.Push(pagination.PageState{
 			ResourceTypeID: resourceTypeUser.Id,
 		})

--- a/pkg/connector/integration_debug_test.go
+++ b/pkg/connector/integration_debug_test.go
@@ -66,13 +66,13 @@ func TestUserResourceTypeList(t *testing.T) {
 
 	o := &userResourceType{
 		resourceType: resourceTypeUser,
-		client:       cliTest.client,
+		connector:    cliTest,
 	}
 	res, _, _, err := o.List(ctxTest, &v2.ResourceId{}, &pagination.Token{})
 	require.Nil(t, err)
 	require.NotNil(t, res)
 
-	oktaUsers, resp, err := o.client.User.ListAssignedRolesForUser(ctxTest, "00ujp5a9z0rMTsPRW697", nil)
+	oktaUsers, resp, err := o.connector.client.User.ListAssignedRolesForUser(ctxTest, "00ujp5a9z0rMTsPRW697", nil)
 	require.Nil(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, oktaUsers)

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -47,7 +47,7 @@ func (o *userResourceType) List(
 	resourceID *v2.ResourceId,
 	token *pagination.Token,
 ) ([]*v2.Resource, string, annotations.Annotations, error) {
-	if o.connector != nil && o.connector.awsConfig != nil && o.connector.awsConfig.Enabled {
+	if o.connector.awsConfig != nil && o.connector.awsConfig.Enabled {
 		awsConfig, err := o.connector.getAWSApplicationConfig(ctx)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("error getting aws app settings config")


### PR DESCRIPTION
- Only get assigned users for aws app when in mode (when group mapping not enabled)
- Fixes bug with with group expand roles (we should not be doing this in aws mode since we do not sync roles) 