### PR TITLE
Increase default page limit to 1000/exclude user credentials/add logs

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -155,7 +155,7 @@ func (o *groupResourceType) Grants(
 		nextPage := ""
 		if !ok || usersCount > 0 {
 			if !ok {
-				l.Info("okta-connectorv2: making list group users call because users_count profile attribute was not present")
+				l.Debug("okta-connectorv2: making list group users call because users_count profile attribute was not present")
 			}
 
 			qp := queryParams(token.Size, page)
@@ -174,7 +174,7 @@ func (o *groupResourceType) Grants(
 				rv = append(rv, groupGrant(resource, user))
 			}
 		} else {
-			l.Info("okta-connectorv2: skipping list group users")
+			l.Debug("okta-connectorv2: skipping list group users")
 		}
 
 		err = bag.Next(nextPage)
@@ -256,7 +256,7 @@ func (o *groupResourceType) Grants(
 			usersCount, ok := sdkResource.GetProfileInt64Value(groupTrait.Profile, usersCountProfileKey)
 			shouldExpand := !ok || usersCount > 0
 			if !shouldExpand {
-				l.Info("okta-connectorv2: skipping expand for role group grant since users_count is 0")
+				l.Debug("okta-connectorv2: skipping expand for role group grant since users_count is 0")
 			}
 			rv = append(rv, roleGroupGrant(groupID, roleResourceVal, shouldExpand))
 		}

--- a/pkg/connector/pagination.go
+++ b/pkg/connector/pagination.go
@@ -11,7 +11,7 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
-const defaultLimit = 500
+const defaultLimit = 1000
 
 func parseGetResp(resp *okta.Response) (annotations.Annotations, error) {
 	var annos annotations.Annotations

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -246,10 +247,31 @@ func listUsers(ctx context.Context, client *okta.Client, token *pagination.Token
 	if qp.Search == "" {
 		qp.Search = "status pr" // ListUsers doesn't get deactivated users by default. this should fetch them all
 	}
-	oktaUsers, resp, err := client.User.ListUsers(ctx, qp)
-	if err != nil {
-		return nil, nil, handleOktaResponseError(resp, err)
+
+	uri := usersUrl
+	if qp != nil {
+		uri += qp.String()
 	}
+
+	reqUrl, err := url.Parse(uri)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	oktaUsers := make([]*okta.User, 0)
+	rq := client.CloneRequestExecutor()
+	req, err := rq.
+		WithAccept(ContentType).
+		WithContentType(`application/json; okta-response="omitCredentials,omitCredentialsLinks,omitTransitioningToStatus"`).
+		NewRequest(http.MethodGet, reqUrl.String(), nil)
+
+	req.Header.Set("Content-Type", `application/json; okta-response="omitCredentials,omitCredentialsLinks,omitTransitioningToStatus"`)
+
+	resp, err := rq.Do(ctx, req, &oktaUsers)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	respCtx, err := responseToContext(token, resp)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -264,6 +264,9 @@ func listUsers(ctx context.Context, client *okta.Client, token *pagination.Token
 		WithAccept(ContentType).
 		WithContentType(`application/json; okta-response="omitCredentials,omitCredentialsLinks,omitTransitioningToStatus"`).
 		NewRequest(http.MethodGet, reqUrl.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req.Header.Set("Content-Type", `application/json; okta-response="omitCredentials,omitCredentialsLinks,omitTransitioningToStatus"`)
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -258,6 +258,9 @@ func listUsers(ctx context.Context, client *okta.Client, token *pagination.Token
 		return nil, nil, err
 	}
 
+	// Using okta-response="omitCredentials,omitCredentialsLinks,omitTransitioningToStatus" in the content type header omits
+	// the credentials, credentials links, and `transitioningToStatus` field from the response which applies performance optimization.
+	// https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers!in=header&path=Content-Type&t=request
 	oktaUsers := make([]*okta.User, 0)
 	rq := client.CloneRequestExecutor()
 	req, err := rq.
@@ -268,6 +271,7 @@ func listUsers(ctx context.Context, client *okta.Client, token *pagination.Token
 		return nil, nil, err
 	}
 
+	// Need to set content type here because the response was still including the credentials when setting it with WithContentType above
 	req.Header.Set("Content-Type", `application/json; okta-response="omitCredentials,omitCredentialsLinks,omitTransitioningToStatus"`)
 
 	resp, err := rq.Do(ctx, req, &oktaUsers)


### PR DESCRIPTION
- Increase default page limit to 1000
- Exclude user credentials for performance optimization https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers!in=header&path=Content-Type&t=request
- Add logs