### PR TITLE
AWS: Check app user schema for group union option/other fixes

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -585,7 +585,7 @@ func getDefaultAppUserSchema(ctx context.Context, client *okta.Client, appId str
 	var appUserSchema *AppUserSchema
 	_, err = rq.Do(ctx, req, &appUserSchema)
 	if err != nil {
-		return nil, fmt.Errorf("okta-aws-connector: error fetching default application schema: %v", err)
+		return nil, fmt.Errorf("okta-aws-connector: error fetching default application schema: %w", err)
 	}
 	return appUserSchema, nil
 }

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -355,6 +355,9 @@ func (o *groupResourceType) listAWSGroups(ctx context.Context, token *pagination
 			return nil, nil, err
 		}
 		oktaGroup, err := embeddedOktaGroupFromAppGroup(appGroup)
+		if err != nil {
+			return nil, nil, fmt.Errorf("okta-aws-connector: failed to fetch groups from okta: %w", err)
+		}
 		groups = append(groups, oktaGroup)
 		awsConfig.appGroupCache.Store(appGroup.Id, appGroupSAMLRoles)
 	}


### PR DESCRIPTION
- Skip user group lookups when "Combine values across groups" is enabled on the AWS app user schema, since the app user profile already contains the union of `samlRoles` from all assigned groups
- Update `UseGroupMapping` to apply to all groups matching the configured regex, not just application groups
- Remove unnecessary uses of `expand=group` - this was only needed to fetch the group display name when generating group resources (since the application group doesn't include this), which is no longer required for `UseGroupMapping` and not needed in `SourceIdentityMode` 
- Include the group resource syncer in `SourceIdentityMode` to support provisioning
- Simplify the app group caching wrapper to store only `samlRoles`, since group and account IDs are no longer needed with the updated `UseGroupMapping` logic
- Fix the app group cache key to use the group ID after fetching the group via API
