### PR TITLE
CXP-203 Returns annotation for GrantAlreadyExists

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -511,7 +511,7 @@ func (g *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 			}
 
 			if errOkta.ErrorCode == alreadyAssignedRole {
-				l.Warn(
+				l.Debug(
 					"okta-connector: The role specified is already assigned to the user",
 					zap.String("principal_id", principal.Id.String()),
 					zap.String("principal_type", principal.Id.ResourceType),

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -518,6 +518,8 @@ func (g *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 					zap.String("ErrorCode", errOkta.ErrorCode),
 					zap.String("ErrorSummary", errOkta.ErrorSummary),
 				)
+
+				return annotations.New(&v2.GrantAlreadyExists{}), nil
 			}
 
 			return nil, fmt.Errorf("okta-connector: %v", errOkta)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role grant operation handling when a role is already assigned to a user. The system now gracefully recognizes this condition and returns a meaningful response instead of signaling a failure, providing clearer feedback on the operation's actual state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->