### PR TITLE
CXH-913 Add skip-app-groups flag to filter APP_GROUP type groups

### DIFF
--- a/cmd/baton-okta/config.go
+++ b/cmd/baton-okta/config.go
@@ -32,6 +32,11 @@ var (
 		"filter-email-domains",
 		field.WithDescription("Only sync users with primary email addresses that match at least one of the provided domains. When unset or empty, all users will be synced."),
 	)
+	skipAppGroups = field.BoolField(
+		"skip-app-groups",
+		field.WithDescription("Skip syncing APP_GROUP type groups (Okta push groups created by SCIM-integrated apps)"),
+		field.WithDefaultValue(false),
+	)
 )
 
 var relationships = []field.SchemaFieldRelationship{
@@ -65,4 +70,5 @@ var configuration = field.NewConfiguration([]field.SchemaField{
 	awsSourceIdentityMode,
 	awsAllowGroupToDirectAssignmentConversionForProvisioning,
 	filterEmailDomains,
+	skipAppGroups,
 }, field.WithConstraints(relationships...))

--- a/cmd/baton-okta/main.go
+++ b/cmd/baton-okta/main.go
@@ -56,6 +56,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		AllowGroupToDirectAssignmentConversionForProvisioning: v.GetBool("aws-allow-group-to-direct-assignment-conversion-for-provisioning"),
 		SyncSecrets:        v.GetBool("sync-secrets"),
 		FilterEmailDomains: v.GetStringSlice("filter-email-domains"),
+		SkipAppGroups:      v.GetBool("skip-app-groups"),
 	}
 
 	cb, err := connector.New(ctx, ccfg)

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -9,7 +9,6 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -71,20 +70,14 @@ var enableUser = &v2.BatonActionSchema{
 	},
 }
 
-func (o *Okta) RegisterActionManager(ctx context.Context) (connectorbuilder.CustomActionManager, error) {
-	actionManager := actions.NewActionManager(ctx)
-
-	err := actionManager.RegisterAction(ctx, enableUser.Name, enableUser, o.enableUser)
-	if err != nil {
-		return nil, err
+func (o *Okta) GlobalActions(ctx context.Context, registry actions.ActionRegistry) error {
+	if err := registry.Register(ctx, enableUser, o.enableUser); err != nil {
+		return err
 	}
-
-	err = actionManager.RegisterAction(ctx, disableUser.Name, disableUser, o.disableUser)
-	if err != nil {
-		return nil, err
+	if err := registry.Register(ctx, disableUser, o.disableUser); err != nil {
+		return err
 	}
-
-	return actionManager, nil
+	return nil
 }
 
 // enableUser "unsuspends" the subject Okta account.

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -92,7 +92,7 @@ type userFilterConfig struct {
 
 type Config struct {
 	Domain                                                string
-	ApiToken                                              string
+	ApiToken                                              string //nolint:gosec // Not a credential
 	OktaClientId                                          string
 	OktaPrivateKey                                        string
 	OktaPrivateKeyId                                      string

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -32,6 +32,7 @@ type Okta struct {
 	ciamConfig          *ciamConfig
 	syncCustomRoles     bool
 	skipSecondaryEmails bool
+	skipAppGroups       bool
 	awsConfig           *awsConfig
 	SyncSecrets         bool
 	userRoleCache       sync.Map
@@ -104,6 +105,7 @@ type Config struct {
 	CacheTTL                                              int32
 	SyncCustomRoles                                       bool
 	SkipSecondaryEmails                                   bool
+	SkipAppGroups                                         bool
 	AWSMode                                               bool
 	AWSOktaAppId                                          string
 	AWSSourceIdentityMode                                 bool
@@ -461,6 +463,7 @@ func New(ctx context.Context, cfg *Config) (*Okta, error) {
 		syncInactiveApps:    cfg.SyncInactiveApps,
 		syncCustomRoles:     cfg.SyncCustomRoles,
 		skipSecondaryEmails: cfg.SkipSecondaryEmails,
+		skipAppGroups:       cfg.SkipAppGroups,
 		SyncSecrets:         cfg.SyncSecrets,
 		ciamConfig: &ciamConfig{
 			Enabled:      cfg.Ciam,

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -27,6 +27,7 @@ import (
 const membershipUpdatedField = "lastMembershipUpdated"
 const usersCountProfileKey = "users_count"
 const builtInGroupType = "BUILT_IN"
+const appGroupType = "APP_GROUP"
 const apiPathGetGroupFmt = "/api/v1/groups/%s"
 
 type groupResourceType struct {
@@ -77,7 +78,12 @@ func (o *groupResourceType) List(
 		return nil, "", nil, fmt.Errorf("okta-connectorv2: failed to fetch bag.Next: %w", err)
 	}
 
+	l := ctxzap.Extract(ctx)
 	for _, group := range groups {
+		if o.connector.skipAppGroups && group.Type == appGroupType {
+			l.Debug("okta-connectorv2: skipping APP_GROUP type group", zap.String("group_id", group.Id))
+			continue
+		}
 		resource, err := o.groupResource(ctx, group)
 		if err != nil {
 			return nil, "", nil, err


### PR DESCRIPTION
Adds a `--skip-app-groups` boolean flag (default `false`) to allow users to opt out of syncing `APP_GROUP` type groups 
- Okta push groups created by SCIM-integrated apps.

Also migrates the deprecated `RegisterActionManager`/`CustomActionManager` interface to `GlobalActions`/`ActionRegistry`.

## Test plan

- Verified `--skip-app-groups` skips APP_GROUP type groups in List() with a debug log
- Default is `false`, preserving existing behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a skip-app-groups configuration flag to let users exclude application groups from Okta synchronization.

* **Refactor**
  * Reworked action registration for linting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->