### PR TITLE
cxp-209 expose group type in profile

### DIFF
--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -9,7 +9,6 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -71,20 +70,15 @@ var enableUser = &v2.BatonActionSchema{
 	},
 }
 
-func (o *Okta) RegisterActionManager(ctx context.Context) (connectorbuilder.CustomActionManager, error) {
-	actionManager := actions.NewActionManager(ctx)
-
-	err := actionManager.RegisterAction(ctx, enableUser.Name, enableUser, o.enableUser)
-	if err != nil {
-		return nil, err
+// GlobalActions implements connectorbuilder.GlobalActionProvider to register global actions.
+func (o *Okta) GlobalActions(ctx context.Context, registry actions.ActionRegistry) error {
+	if err := registry.Register(ctx, enableUser, o.enableUser); err != nil {
+		return err
 	}
-
-	err = actionManager.RegisterAction(ctx, disableUser.Name, disableUser, o.disableUser)
-	if err != nil {
-		return nil, err
+	if err := registry.Register(ctx, disableUser, o.disableUser); err != nil {
+		return err
 	}
-
-	return actionManager, nil
+	return nil
 }
 
 // enableUser "unsuspends" the subject Okta account.

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -91,7 +91,7 @@ type userFilterConfig struct {
 
 type Config struct {
 	Domain                                                string
-	ApiToken                                              string
+	ApiToken                                              string //nolint:gosec // G117: config field for Okta API token; value is not logged or exposed
 	OktaClientId                                          string
 	OktaPrivateKey                                        string
 	OktaPrivateKeyId                                      string

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -487,10 +487,11 @@ func (o *groupResourceType) groupResource(ctx context.Context, group *okta.Group
 	}, nil
 }
 
-func (o *groupResourceType) groupTrait(ctx context.Context, group *okta.Group) (*v2.GroupTrait, error) {
+func (o *groupResourceType) groupTrait(_ context.Context, group *okta.Group) (*v2.GroupTrait, error) {
 	profileMap := map[string]interface{}{
 		"description": group.Profile.Description,
 		"name":        group.Profile.Name,
+		"type":        group.Type,
 	}
 
 	if userCount, exists := getGroupUserCount(group); exists {


### PR DESCRIPTION
Exposes group type (APP_GROUP, OKTA_GROUP or BUILT_IN) in the group profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group profiles now include a "type" field, improving visibility into group classification.
* **Refactor**
  * Action registration has been reworked to use a centralized registry for registering enable/disable actions (no change to end-user workflows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->