### PR TITLE
 feat: add group creation and deletion resource actions Add ResourceActionProvider and ResourceDeleterV2Limited implementations to groupResourceType, enabling Okta group create and delete operations via the Baton action framework.

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -1,189 +1,191 @@
 {
-  "@type":  "type.googleapis.com/c1.connector.v2.ConnectorCapabilities",
-  "resourceTypeCapabilities":  [
+  "@type": "type.googleapis.com/c1.connector.v2.ConnectorCapabilities",
+  "resourceTypeCapabilities": [
     {
-      "resourceType":  {
-        "id":  "api-token",
-        "displayName":  "API Token",
-        "traits":  [
+      "resourceType": {
+        "id": "api-token",
+        "displayName": "API Token",
+        "traits": [
           "TRAIT_SECRET"
         ],
-        "annotations":  [
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id":  "api-token"
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "api-token"
           },
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC"
       ],
-      "permissions":  {}
+      "permissions": {}
     },
     {
-      "resourceType":  {
-        "id":  "app",
-        "displayName":  "App",
-        "traits":  [
+      "resourceType": {
+        "id": "app",
+        "displayName": "App",
+        "traits": [
           "TRAIT_APP"
         ],
-        "annotations":  [
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id":  "app"
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "app"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions":  {}
+      "permissions": {}
     },
     {
-      "resourceType":  {
-        "id":  "custom-role",
-        "displayName":  "Custom Role",
-        "traits":  [
+      "resourceType": {
+        "id": "custom-role",
+        "displayName": "Custom Role",
+        "traits": [
           "TRAIT_ROLE"
         ],
-        "annotations":  [
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id":  "custom-role"
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "custom-role"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC"
       ],
-      "permissions":  {}
+      "permissions": {}
     },
     {
-      "resourceType":  {
-        "id":  "group",
-        "displayName":  "Group",
-        "traits":  [
+      "resourceType": {
+        "id": "group",
+        "displayName": "Group",
+        "traits": [
           "TRAIT_GROUP"
         ],
-        "annotations":  [
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id":  "group"
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "group"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
+        "CAPABILITY_SYNC",
+        "CAPABILITY_TARGETED_SYNC",
+        "CAPABILITY_PROVISION",
+        "CAPABILITY_RESOURCE_DELETE"
+      ],
+      "permissions": {}
+    },
+    {
+      "resourceType": {
+        "id": "resource-set",
+        "displayName": "Resource Set",
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "resource-set"
+          }
+        ]
+      },
+      "capabilities": [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions":  {}
+      "permissions": {}
     },
     {
-      "resourceType":  {
-        "id":  "resource-set",
-        "displayName":  "Resource Set",
-        "annotations":  [
+      "resourceType": {
+        "id": "resourceset-binding",
+        "displayName": "Resource Set Binding",
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id":  "resource-set"
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "resourceset-binding"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions":  {}
+      "permissions": {}
     },
     {
-      "resourceType":  {
-        "id":  "resourceset-binding",
-        "displayName":  "Resource Set Binding",
-        "annotations":  [
-          {
-            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id":  "resourceset-binding"
-          }
-        ]
-      },
-      "capabilities":  [
-        "CAPABILITY_SYNC",
-        "CAPABILITY_TARGETED_SYNC",
-        "CAPABILITY_PROVISION"
-      ],
-      "permissions":  {}
-    },
-    {
-      "resourceType":  {
-        "id":  "role",
-        "displayName":  "Role",
-        "traits":  [
+      "resourceType": {
+        "id": "role",
+        "displayName": "Role",
+        "traits": [
           "TRAIT_ROLE"
         ],
-        "annotations":  [
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id":  "role"
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "role"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions":  {}
+      "permissions": {}
     },
     {
-      "resourceType":  {
-        "id":  "user",
-        "displayName":  "User",
-        "traits":  [
+      "resourceType": {
+        "id": "user",
+        "displayName": "User",
+        "traits": [
           "TRAIT_USER"
         ],
-        "annotations":  [
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id":  "user"
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "user"
           },
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_ACCOUNT_PROVISIONING"
       ],
-      "permissions":  {}
+      "permissions": {}
     }
   ],
-  "connectorCapabilities":  [
+  "connectorCapabilities": [
     "CAPABILITY_PROVISION",
     "CAPABILITY_SYNC",
     "CAPABILITY_ACCOUNT_PROVISIONING",
+    "CAPABILITY_RESOURCE_DELETE",
     "CAPABILITY_ACTIONS",
     "CAPABILITY_TARGETED_SYNC",
     "CAPABILITY_EVENT_FEED_V2",
     "CAPABILITY_SERVICE_MODE_TARGETED_SYNC"
   ],
-  "credentialDetails":  {
-    "capabilityAccountProvisioning":  {
-      "supportedCredentialOptions":  [
+  "credentialDetails": {
+    "capabilityAccountProvisioning": {
+      "supportedCredentialOptions": [
         "CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD",
         "CAPABILITY_DETAIL_CREDENTIAL_OPTION_RANDOM_PASSWORD"
       ],
-      "preferredCredentialOption":  "CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD"
+      "preferredCredentialOption": "CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD"
     }
   }
 }

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -12,14 +12,14 @@ sidebarTitle: "Okta"
 
 ## Capabilities
 
-| Resource | Sync | Provision |
-| :--- | :--- | :--- |
-| Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
-| Applications | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
-| Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
-| Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
-| Standard and custom admin roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
-| Secrets - API tokens | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Resource | Sync | Provision | Delete |
+| :--- | :--- | :--- | :--- |
+| Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Applications | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Standard and custom admin roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |  |
+| Secrets - API tokens | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |  |
 
 <Note>
 The standard roles **Workflows Administrator**, **Access Certifications Administrator**, and **Access Requests Administrator** appear as Custom Roles in C1. Enable **Sync Custom Roles** to see them. The Okta API returns these roles through the same endpoint as custom roles.
@@ -41,6 +41,8 @@ Connector actions are custom capabilities that extend C1 automations with app-sp
 |-------------|-------------------|-------------|
 | enable_user | `user_id` (string, required) | Unsuspends a suspended Okta user account |
 | disable_user     | `user_id` (string, required) | Suspends an active Okta user account |
+| create | `name` (string, required), `description` (string), `userMembers` (resource ID list) | Creates a new Okta group with optional initial members |
+| modify_group | `group_id` (string, required), `name` (string), `description` (string) | Updates the name and/or description of an existing Okta group |
 
 ## Gather Okta credentials 
 

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -690,7 +690,7 @@ func (o *groupResourceType) handleModifyGroupAction(ctx context.Context, args *s
 		defer updateResp.Body.Close()
 	}
 
-	l.Info("updated Okta group", zap.String("groupId", updatedGroup.Id), zap.String("name", updatedGroup.Profile.Name))
+	l.Info("updated Okta group", zap.String("groupId", updatedGroup.Id), zap.String("name", profile.Name))
 
 	resource, err := o.groupResource(ctx, updatedGroup)
 	if err != nil {
@@ -783,17 +783,19 @@ func (o *groupResourceType) handleCreateGroupAction(ctx context.Context, args *s
 
 	l.Info("created Okta group", zap.String("groupId", createdGroup.Id), zap.String("name", groupName))
 
-	userMemberIDs, _ := actions.GetResourceIdListArg(args, "userMembers")
-	for _, memberID := range userMemberIDs {
-		memberResp, err := o.connector.client.Group.AddUserToGroup(ctx, createdGroup.Id, memberID.Resource)
-		if err != nil {
+	userMemberIDs, ok := actions.GetResourceIdListArg(args, "userMembers")
+	if ok {
+		for _, memberID := range userMemberIDs {
+			memberResp, err := o.connector.client.Group.AddUserToGroup(ctx, createdGroup.Id, memberID.Resource)
+			if err != nil {
+				if memberResp != nil {
+					memberResp.Body.Close()
+				}
+				return nil, nil, fmt.Errorf("okta-connectorv2: group %s created but failed to add member %s: %w", createdGroup.Id, memberID.Resource, err)
+			}
 			if memberResp != nil {
 				memberResp.Body.Close()
 			}
-			return nil, nil, fmt.Errorf("okta-connectorv2: group %s created but failed to add member %s: %w", createdGroup.Id, memberID.Resource, err)
-		}
-		if memberResp != nil {
-			memberResp.Body.Close()
 		}
 	}
 
@@ -831,6 +833,7 @@ func (o *groupResourceType) Delete(ctx context.Context, resourceId *v2.ResourceI
 	l.Info("deleted Okta group", zap.String("groupId", groupId))
 	return nil, nil
 }
+
 func groupBuilder(connector *Okta) *groupResourceType {
 	return &groupResourceType{
 		resourceType: resourceTypeGroup,

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -646,6 +646,10 @@ func (o *groupResourceType) handleModifyGroupAction(ctx context.Context, args *s
 		defer resp.Body.Close()
 	}
 
+	if existingGroup.Profile == nil {
+		return nil, nil, fmt.Errorf("okta-connectorv2: group %s has no profile", groupId)
+	}
+
 	// Build updated profile, preserving existing values for fields not provided
 	profile := &okta.GroupProfile{
 		Name:        existingGroup.Profile.Name,
@@ -733,7 +737,7 @@ func (o *groupResourceType) registerCreateGroupAction(ctx context.Context, regis
 				Field: &config.Field_ResourceIdSliceField{
 					ResourceIdSliceField: &config.ResourceIdSliceField{
 						Rules: &config.RepeatedResourceIdRules{
-							AllowedResourceTypeIds: []string{"user"},
+							AllowedResourceTypeIds: []string{resourceTypeUser.Id},
 						},
 					},
 				},
@@ -783,15 +787,10 @@ func (o *groupResourceType) handleCreateGroupAction(ctx context.Context, args *s
 	for _, memberID := range userMemberIDs {
 		memberResp, err := o.connector.client.Group.AddUserToGroup(ctx, createdGroup.Id, memberID.Resource)
 		if err != nil {
-			l.Warn("failed to add initial member to group, skipping",
-				zap.String("userId", memberID.Resource),
-				zap.String("groupId", createdGroup.Id),
-				zap.Error(err),
-			)
 			if memberResp != nil {
 				memberResp.Body.Close()
 			}
-			continue
+			return nil, nil, fmt.Errorf("okta-connectorv2: group %s created but failed to add member %s: %w", createdGroup.Id, memberID.Resource, err)
 		}
 		if memberResp != nil {
 			memberResp.Body.Close()
@@ -823,7 +822,7 @@ func (o *groupResourceType) Delete(ctx context.Context, resourceId *v2.ResourceI
 			defer resp.Body.Close()
 		}
 		l.Error("failed to delete Okta group", zap.String("groupId", groupId), zap.Error(err))
-		return nil, handleOktaResponseError(resp, fmt.Errorf("okta-connectorv2: failed to delete group: %w", err))
+		return nil, handleOktaResponseError(resp, err)
 	}
 	if resp != nil {
 		defer resp.Body.Close()

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -7,20 +7,25 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/conductorone/baton-sdk/pkg/ratelimit"
-	sdkResource "github.com/conductorone/baton-sdk/pkg/types/resource"
-	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/structpb"
-
+	config "github.com/conductorone/baton-sdk/pb/c1/config/v1"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 	sdkEntitlement "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	sdkGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
+	sdkResource "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
 )
+
+var _ connectorbuilder.ResourceActionProvider = (*groupResourceType)(nil)
+var _ connectorbuilder.ResourceDeleterV2Limited = (*groupResourceType)(nil)
 
 const membershipUpdatedField = "lastMembershipUpdated"
 const usersCountProfileKey = "users_count"
@@ -557,6 +562,141 @@ func (o *groupResourceType) Get(ctx context.Context, resourceId *v2.ResourceId, 
 	return resource, annos, nil
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func (o *groupResourceType) ResourceActions(ctx context.Context, registry actions.ActionRegistry) error {
+	return registry.Register(ctx, &v2.BatonActionSchema{
+		Name: "create",
+		Arguments: []*config.Field{
+			{
+				Name:        "name",
+				DisplayName: "Group Name",
+				Description: "The name of the Okta group to create",
+				Field: &config.Field_StringField{
+					StringField: &config.StringField{
+						Rules: &config.StringRules{
+							MinLen: ptr(uint64(1)),
+							MaxLen: ptr(uint64(255)),
+						},
+					},
+				},
+				IsRequired: true,
+			},
+			{
+				Name:        "description",
+				DisplayName: "Description",
+				Description: "Description of the group",
+				Field:       &config.Field_StringField{},
+				IsRequired:  false,
+			},
+			{
+				Name:        "userMembers",
+				DisplayName: "Initial User Members",
+				Description: "List of user resource IDs to add as initial members",
+				Field: &config.Field_ResourceIdSliceField{
+					ResourceIdSliceField: &config.ResourceIdSliceField{
+						Rules: &config.RepeatedResourceIdRules{
+							AllowedResourceTypeIds: []string{"user"},
+						},
+					},
+				},
+				IsRequired: false,
+			},
+		},
+		ReturnTypes: []*config.Field{
+			{Name: "success", DisplayName: "Success", Field: &config.Field_BoolField{}},
+			{Name: "resource", DisplayName: "Created Group", Field: &config.Field_ResourceField{}},
+		},
+		ActionType: []v2.ActionType{v2.ActionType_ACTION_TYPE_RESOURCE_CREATE},
+	}, o.handleCreateGroupAction)
+}
+
+func (o *groupResourceType) handleCreateGroupAction(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+
+	groupName, err := actions.RequireStringArg(args, "name")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	description, _ := actions.GetStringArg(args, "description")
+
+	newGroup := okta.Group{
+		Profile: &okta.GroupProfile{
+			Name:        groupName,
+			Description: description,
+		},
+	}
+
+	createdGroup, resp, err := o.connector.client.Group.CreateGroup(ctx, newGroup)
+	if err != nil {
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		l.Error("failed to create Okta group", zap.Error(err), zap.String("name", groupName))
+		return nil, nil, fmt.Errorf("okta-connectorv2: failed to create group: %w", err)
+	}
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	l.Info("created Okta group", zap.String("groupId", createdGroup.Id), zap.String("name", groupName))
+
+	userMemberIDs, _ := actions.GetResourceIdListArg(args, "userMembers")
+	for _, memberID := range userMemberIDs {
+		memberResp, err := o.connector.client.Group.AddUserToGroup(ctx, createdGroup.Id, memberID.Resource)
+		if err != nil {
+			l.Warn("failed to add initial member to group, skipping",
+				zap.String("userId", memberID.Resource),
+				zap.String("groupId", createdGroup.Id),
+				zap.Error(err),
+			)
+			if memberResp != nil {
+				memberResp.Body.Close()
+			}
+			continue
+		}
+		if memberResp != nil {
+			memberResp.Body.Close()
+		}
+	}
+
+	resource, err := o.groupResource(ctx, createdGroup)
+	if err != nil {
+		l.Error("failed to build group resource after creation", zap.Error(err))
+		return nil, nil, fmt.Errorf("okta-connectorv2: group created but failed to build resource: %w", err)
+	}
+
+	resourceRv, err := actions.NewResourceReturnField("resource", resource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return actions.NewReturnValues(true, resourceRv), nil, nil
+}
+
+func (o *groupResourceType) Delete(ctx context.Context, resourceId *v2.ResourceId, parentResourceID *v2.ResourceId) (annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+
+	groupId := resourceId.Resource
+
+	resp, err := o.connector.client.Group.DeleteGroup(ctx, groupId)
+	if err != nil {
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		l.Error("failed to delete Okta group", zap.String("groupId", groupId), zap.Error(err))
+		return nil, handleOktaResponseError(resp, fmt.Errorf("okta-connectorv2: failed to delete group: %w", err))
+	}
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	l.Info("deleted Okta group", zap.String("groupId", groupId))
+	return nil, nil
+}
 func groupBuilder(connector *Okta) *groupResourceType {
 	return &groupResourceType{
 		resourceType: resourceTypeGroup,

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -562,10 +562,6 @@ func (o *groupResourceType) Get(ctx context.Context, resourceId *v2.ResourceId, 
 	return resource, annos, nil
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func (o *groupResourceType) ResourceActions(ctx context.Context, registry actions.ActionRegistry) error {
 	if err := o.registerCreateGroupAction(ctx, registry); err != nil {
 		return err
@@ -596,8 +592,8 @@ func (o *groupResourceType) registerModifyGroupAction(ctx context.Context, regis
 				Field: &config.Field_StringField{
 					StringField: &config.StringField{
 						Rules: &config.StringRules{
-							MinLen: ptr(uint64(1)),
-							MaxLen: ptr(uint64(255)),
+							MinLen: ToPtr(uint64(1)),
+							MaxLen: ToPtr(uint64(255)),
 						},
 					},
 				},
@@ -716,8 +712,8 @@ func (o *groupResourceType) registerCreateGroupAction(ctx context.Context, regis
 				Field: &config.Field_StringField{
 					StringField: &config.StringField{
 						Rules: &config.StringRules{
-							MinLen: ptr(uint64(1)),
-							MaxLen: ptr(uint64(255)),
+							MinLen: ToPtr(uint64(1)),
+							MaxLen: ToPtr(uint64(255)),
 						},
 					},
 				},

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -567,6 +567,141 @@ func ptr[T any](v T) *T {
 }
 
 func (o *groupResourceType) ResourceActions(ctx context.Context, registry actions.ActionRegistry) error {
+	if err := o.registerCreateGroupAction(ctx, registry); err != nil {
+		return err
+	}
+	if err := o.registerModifyGroupAction(ctx, registry); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *groupResourceType) registerModifyGroupAction(ctx context.Context, registry actions.ActionRegistry) error {
+	return registry.Register(ctx, &v2.BatonActionSchema{
+		Name:        "modify_group",
+		DisplayName: "Modify Group",
+		Description: "Update the name and/or description of an existing Okta group.",
+		Arguments: []*config.Field{
+			{
+				Name:        "group_id",
+				DisplayName: "Group ID",
+				Description: "The Okta group ID to modify.",
+				Field:       &config.Field_StringField{},
+				IsRequired:  true,
+			},
+			{
+				Name:        "name",
+				DisplayName: "Group Name",
+				Description: "The new name for the group.",
+				Field: &config.Field_StringField{
+					StringField: &config.StringField{
+						Rules: &config.StringRules{
+							MinLen: ptr(uint64(1)),
+							MaxLen: ptr(uint64(255)),
+						},
+					},
+				},
+				IsRequired: false,
+			},
+			{
+				Name:        "description",
+				DisplayName: "Description",
+				Description: "The new description for the group.",
+				Field:       &config.Field_StringField{},
+				IsRequired: false,
+			},
+		},
+		ReturnTypes: []*config.Field{
+			{Name: "success", DisplayName: "Success", Field: &config.Field_BoolField{}},
+			{Name: "resource", DisplayName: "Updated Group", Field: &config.Field_ResourceField{}},
+		},
+		ActionType: []v2.ActionType{v2.ActionType_ACTION_TYPE_UNSPECIFIED},
+	}, o.handleModifyGroupAction)
+}
+
+func (o *groupResourceType) handleModifyGroupAction(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+
+	groupId, err := actions.RequireStringArg(args, "group_id")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newName, hasName := actions.GetStringArg(args, "name")
+	newDescription, hasDescription := actions.GetStringArg(args, "description")
+
+	if !hasName && !hasDescription {
+		return nil, nil, fmt.Errorf("okta-connectorv2: at least one of name or description must be provided")
+	}
+
+	// Fetch the current group to get existing values
+	existingGroup, resp, err := o.connector.client.Group.GetGroup(ctx, groupId)
+	if err != nil {
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		return nil, nil, fmt.Errorf("okta-connectorv2: failed to get group %s: %w", groupId, err)
+	}
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	// Build updated profile, preserving existing values for fields not provided
+	profile := &okta.GroupProfile{
+		Name:        existingGroup.Profile.Name,
+		Description: existingGroup.Profile.Description,
+	}
+	if hasName {
+		profile.Name = newName
+	}
+	if hasDescription {
+		profile.Description = newDescription
+	}
+
+	// Check if anything actually changed (idempotency)
+	if profile.Name == existingGroup.Profile.Name && profile.Description == existingGroup.Profile.Description {
+		l.Debug("okta-connectorv2: group already has requested values, no update needed", zap.String("groupId", groupId))
+		resource, err := o.groupResource(ctx, existingGroup)
+		if err != nil {
+			return nil, nil, fmt.Errorf("okta-connectorv2: failed to build group resource: %w", err)
+		}
+		resourceRv, err := actions.NewResourceReturnField("resource", resource)
+		if err != nil {
+			return nil, nil, err
+		}
+		return actions.NewReturnValues(true, resourceRv), nil, nil
+	}
+
+	updatedGroup, updateResp, err := o.connector.client.Group.UpdateGroup(ctx, groupId, okta.Group{
+		Profile: profile,
+	})
+	if err != nil {
+		if updateResp != nil {
+			defer updateResp.Body.Close()
+		}
+		l.Error("failed to update Okta group", zap.String("groupId", groupId), zap.Error(err))
+		return nil, nil, fmt.Errorf("okta-connectorv2: failed to update group: %w", err)
+	}
+	if updateResp != nil {
+		defer updateResp.Body.Close()
+	}
+
+	l.Info("updated Okta group", zap.String("groupId", updatedGroup.Id), zap.String("name", updatedGroup.Profile.Name))
+
+	resource, err := o.groupResource(ctx, updatedGroup)
+	if err != nil {
+		return nil, nil, fmt.Errorf("okta-connectorv2: group updated but failed to build resource: %w", err)
+	}
+
+	resourceRv, err := actions.NewResourceReturnField("resource", resource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return actions.NewReturnValues(true, resourceRv), nil, nil
+}
+
+func (o *groupResourceType) registerCreateGroupAction(ctx context.Context, registry actions.ActionRegistry) error {
 	return registry.Register(ctx, &v2.BatonActionSchema{
 		Name: "create",
 		Arguments: []*config.Field{


### PR DESCRIPTION
 feat: add group creation and deletion resource actions Add ResourceActionProvider and ResourceDeleterV2Limited implementations to groupResourceType, enabling Okta group create and delete operations via the Baton action framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create Okta groups via connector actions, with optional initial member assignment.
  * Modify existing Okta groups (name/description) with idempotent handling.
  * Delete Okta groups through connector actions.
* **Chores**
  * Added action registration and plumbing to support the new create/modify/delete actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->