### PR TITLE
[CXP-369] Reduce page sizes for grants sync to prevent Lambda timeouts

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -1,174 +1,174 @@
 {
-  "@type": "type.googleapis.com/c1.connector.v2.ConnectorCapabilities",
-  "resourceTypeCapabilities": [
+  "@type":  "type.googleapis.com/c1.connector.v2.ConnectorCapabilities",
+  "resourceTypeCapabilities":  [
     {
-      "resourceType": {
-        "id": "api-token",
-        "displayName": "API Token",
-        "traits": [
+      "resourceType":  {
+        "id":  "api-token",
+        "displayName":  "API Token",
+        "traits":  [
           "TRAIT_SECRET"
         ],
-        "annotations": [
+        "annotations":  [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id": "api-token"
+            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id":  "api-token"
           },
           {
-            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+            "@type":  "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
           }
         ]
       },
-      "capabilities": [
+      "capabilities":  [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC"
       ],
-      "permissions": {}
+      "permissions":  {}
     },
     {
-      "resourceType": {
-        "id": "app",
-        "displayName": "App",
-        "traits": [
+      "resourceType":  {
+        "id":  "app",
+        "displayName":  "App",
+        "traits":  [
           "TRAIT_APP"
         ],
-        "annotations": [
+        "annotations":  [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id": "app"
+            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id":  "app"
           }
         ]
       },
-      "capabilities": [
+      "capabilities":  [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions": {}
+      "permissions":  {}
     },
     {
-      "resourceType": {
-        "id": "custom-role",
-        "displayName": "Custom Role",
-        "traits": [
+      "resourceType":  {
+        "id":  "custom-role",
+        "displayName":  "Custom Role",
+        "traits":  [
           "TRAIT_ROLE"
         ],
-        "annotations": [
+        "annotations":  [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id": "custom-role"
+            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id":  "custom-role"
           }
         ]
       },
-      "capabilities": [
+      "capabilities":  [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC"
       ],
-      "permissions": {}
+      "permissions":  {}
     },
     {
-      "resourceType": {
-        "id": "group",
-        "displayName": "Group",
-        "traits": [
+      "resourceType":  {
+        "id":  "group",
+        "displayName":  "Group",
+        "traits":  [
           "TRAIT_GROUP"
         ],
-        "annotations": [
+        "annotations":  [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id": "group"
+            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id":  "group"
           }
         ]
       },
-      "capabilities": [
+      "capabilities":  [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions": {}
+      "permissions":  {}
     },
     {
-      "resourceType": {
-        "id": "resource-set",
-        "displayName": "Resource Set",
-        "annotations": [
+      "resourceType":  {
+        "id":  "resource-set",
+        "displayName":  "Resource Set",
+        "annotations":  [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id": "resource-set"
+            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id":  "resource-set"
           }
         ]
       },
-      "capabilities": [
+      "capabilities":  [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions": {}
+      "permissions":  {}
     },
     {
-      "resourceType": {
-        "id": "resourceset-binding",
-        "displayName": "Resource Set Binding",
-        "annotations": [
+      "resourceType":  {
+        "id":  "resourceset-binding",
+        "displayName":  "Resource Set Binding",
+        "annotations":  [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id": "resourceset-binding"
+            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id":  "resourceset-binding"
           }
         ]
       },
-      "capabilities": [
+      "capabilities":  [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions": {}
+      "permissions":  {}
     },
     {
-      "resourceType": {
-        "id": "role",
-        "displayName": "Role",
-        "traits": [
+      "resourceType":  {
+        "id":  "role",
+        "displayName":  "Role",
+        "traits":  [
           "TRAIT_ROLE"
         ],
-        "annotations": [
+        "annotations":  [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id": "role"
+            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id":  "role"
           }
         ]
       },
-      "capabilities": [
+      "capabilities":  [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_PROVISION"
       ],
-      "permissions": {}
+      "permissions":  {}
     },
     {
-      "resourceType": {
-        "id": "user",
-        "displayName": "User",
-        "traits": [
+      "resourceType":  {
+        "id":  "user",
+        "displayName":  "User",
+        "traits":  [
           "TRAIT_USER"
         ],
-        "annotations": [
+        "annotations":  [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
-            "id": "user"
+            "@type":  "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id":  "user"
           },
           {
-            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+            "@type":  "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
           }
         ]
       },
-      "capabilities": [
+      "capabilities":  [
         "CAPABILITY_SYNC",
         "CAPABILITY_TARGETED_SYNC",
         "CAPABILITY_ACCOUNT_PROVISIONING"
       ],
-      "permissions": {}
+      "permissions":  {}
     }
   ],
-  "connectorCapabilities": [
+  "connectorCapabilities":  [
     "CAPABILITY_PROVISION",
     "CAPABILITY_SYNC",
     "CAPABILITY_ACCOUNT_PROVISIONING",
@@ -177,13 +177,13 @@
     "CAPABILITY_EVENT_FEED_V2",
     "CAPABILITY_SERVICE_MODE_TARGETED_SYNC"
   ],
-  "credentialDetails": {
-    "capabilityAccountProvisioning": {
-      "supportedCredentialOptions": [
+  "credentialDetails":  {
+    "capabilityAccountProvisioning":  {
+      "supportedCredentialOptions":  [
         "CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD",
         "CAPABILITY_DETAIL_CREDENTIAL_OPTION_RANDOM_PASSWORD"
       ],
-      "preferredCredentialOption": "CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD"
+      "preferredCredentialOption":  "CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD"
     }
   }
 }

--- a/pkg/connector/custom_role.go
+++ b/pkg/connector/custom_role.go
@@ -142,7 +142,7 @@ func (o *customRoleResourceType) Grants(
 		return nil, nil, fmt.Errorf("okta-connectorv2: failed to parse page token: %w", err)
 	}
 
-	qp := queryParams(token.Size, page)
+	qp := queryParams(roleAssignmentsPageSize, page)
 
 	usersWithRoleAssignments, respCtx, err := listAllUsersWithRoleAssignments(ctx, o.connector.client, token, qp)
 	if err != nil {

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -157,7 +157,7 @@ func (o *groupResourceType) Grants(
 				l.Debug("okta-connectorv2: making list group users call because users_count profile attribute was not present")
 			}
 
-			qp := queryParams(token.Size, page)
+			qp := queryParams(groupUsersPageSize, page)
 
 			users, respCtx, err := o.listGroupUsers(ctx, groupID, token, qp)
 			if err != nil {

--- a/pkg/connector/pagination.go
+++ b/pkg/connector/pagination.go
@@ -11,7 +11,25 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
-const defaultLimit = 1000
+const (
+	defaultLimit = 1000
+
+	// roleAssignmentsPageSize limits the number of users fetched per page from
+	// /api/v1/iam/assignees/users during role grants sync (Okta default is 100).
+	// Each user on the page triggers an individual API call to
+	// /api/v1/users/{id}/roles, so a smaller page size reduces the fan-out of
+	// API calls per sync operation. This prevents Lambda execution timeouts when
+	// syncing tenants with many users.
+	// https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RoleAssignment/#tag/RoleAssignment/operation/listUsersWithRoleAssignments
+	roleAssignmentsPageSize = 50
+
+	// groupUsersPageSize limits the number of users fetched per page from
+	// /api/v1/groups/{id}/users during group grants sync (Okta default is 1000,
+	// but Okta recommends 200). Large pages can produce responses that cause
+	// unexpected EOF errors on large groups.
+	// https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroupUsers
+	groupUsersPageSize = 200
+)
 
 func parseResp(resp *okta.Response) (string, annotations.Annotations, error) {
 	var annos annotations.Annotations

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -148,7 +148,7 @@ func (o *roleResourceType) Grants(
 		return nil, nil, fmt.Errorf("okta-connectorv2: failed to parse page token: %w", err)
 	}
 
-	qp := queryParams(token.Size, page)
+	qp := queryParams(roleAssignmentsPageSize, page)
 
 	usersWithRoleAssignments, respCtx, err := listAllUsersWithRoleAssignments(ctx, o.connector.client, token, qp)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Reduces page size for `/api/v1/iam/assignees/users` from the Okta default of 100 to 50 during role/custom role grants sync. Each user on the page fans out to an individual `/api/v1/users/{id}/roles` call, so halving the page size halves the number of API calls per sync operation.
- Reduces page size for `/api/v1/groups/{id}/users` from 1000 to 200 during group grants sync, matching [Okta's recommended limit](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroupUsers). Large responses from this endpoint were causing unexpected EOF errors.
- Both changes result in more pages (more Lambda invocations) but each invocation completes within the execution deadline.

## Test plan
- [x] Deployed `v0.5.1-test.1` to affected tenants
- [x] Verify full sync completes without Lambda timeout errors
- [x] Verify grant counts match previous successful syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)