### PR TITLE
chore: update baton-sdk to v0.8.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/conductorone/baton-okta
 go 1.25.2
 
 require (
-	github.com/conductorone/baton-sdk v0.8.17
+	github.com/conductorone/baton-sdk v0.8.18
 	github.com/conductorone/okta-sdk-golang/v5 v5.0.6-conductorone
 	github.com/deckarep/golang-set/v2 v2.7.0
 	github.com/ennyjfrick/ruleguard-logfatal v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/conductorone/baton-sdk v0.8.17 h1:k++l6LV5uU4wmoP20mWFJcpgpgHCVrqZU/tbJ+sQ1dA=
-github.com/conductorone/baton-sdk v0.8.17/go.mod h1:agmFrml6APUw4ZlqMEBrnXYj3aAOGKOJ6gztiNj64h0=
+github.com/conductorone/baton-sdk v0.8.18 h1:GvuIVxsnTlg0gdR1hY2qpr68gq49hRxZfIkYOIFqPWY=
+github.com/conductorone/baton-sdk v0.8.18/go.mod h1:agmFrml6APUw4ZlqMEBrnXYj3aAOGKOJ6gztiNj64h0=
 github.com/conductorone/dpop v0.2.3 h1:s91U3845GHQ6P6FWrdNr2SEOy1ES/jcFs1JtKSl2S+o=
 github.com/conductorone/dpop v0.2.3/go.mod h1:gyo8TtzB9SCFCsjsICH4IaLZ7y64CcrDXMOPBwfq/3s=
 github.com/conductorone/dpop/integrations/dpop_grpc v0.2.3 h1:kLMCNIh0Mo2vbvvkCmJ3ixsPbXEJ6HPcW53Ku9yje3s=

--- a/vendor/github.com/conductorone/baton-sdk/pkg/lambda/grpc/client.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/lambda/grpc/client.go
@@ -38,6 +38,9 @@ func (l *lambdaTransport) RoundTrip(ctx context.Context, req *Request) (*Respons
 	// Invoke the Lambda function.
 	invokeResp, err := l.lambdaClient.Invoke(ctx, input)
 	if err != nil {
+		if isTransientNetworkError(err) {
+			return nil, status.Errorf(codes.Unavailable, "lambda_transport: transient network error invoking function: %s", err)
+		}
 		return nil, fmt.Errorf("lambda_transport: failed to invoke lambda function: %w", err)
 	}
 

--- a/vendor/github.com/conductorone/baton-sdk/pkg/lambda/grpc/util.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/lambda/grpc/util.go
@@ -129,9 +129,26 @@ func UnmarshalMetadata(s *structpb.Struct) metadata.MD {
 	return md
 }
 
+// isTransientNetworkError returns true for TCP-level errors that are
+// transient and should be classified as codes.Unavailable rather than
+// codes.Unknown so that callers (e.g. IsSyncPreservable) can treat
+// them as recoverable.
+func isTransientNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "no such host") ||
+		(strings.Contains(msg, "unexpected EOF") && !strings.Contains(msg, "unexpected EOF on client connection"))
+}
+
 // ErrorResponse converts a given error to a status.Status and returns a *pbtransport.Response.
 // status.FromError(err) must unwrap a status.Status for this to work - all other errors are converted
-// to grpc codes.Unknown errors.
+// to grpc codes.Unknown errors. Transient network errors are classified as codes.Unavailable.
 func ErrorResponse(err error) *Response {
 	st, ok := status.FromError(err)
 	if !ok {
@@ -140,6 +157,8 @@ func ErrorResponse(err error) *Response {
 			st = status.Newf(codes.Canceled, "canceled: %s", err)
 		case errors.Is(err, context.DeadlineExceeded):
 			st = status.Newf(codes.DeadlineExceeded, "deadline exceeded: %s", err)
+		case isTransientNetworkError(err):
+			st = status.Newf(codes.Unavailable, "transient network error: %s", err)
 		default:
 			st = status.Newf(codes.Unknown, "unknown error: %s", err)
 		}

--- a/vendor/github.com/conductorone/baton-sdk/pkg/sdk/version.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/sdk/version.go
@@ -1,3 +1,3 @@
 package sdk
 
-const Version = "v0.8.16"
+const Version = "v0.8.17"

--- a/vendor/github.com/conductorone/baton-sdk/pkg/uhttp/transport.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/uhttp/transport.go
@@ -109,18 +109,25 @@ func (uat *userAgentTripper) RoundTrip(req *http.Request) (*http.Response, error
 
 func (t *Transport) make(_ context.Context) (http.RoundTripper, error) {
 	// based on http.DefaultTransport
+	//
+	// Key tuning for Lambda-behind-proxy environments:
+	// - IdleConnTimeout is set shorter than typical proxy idle timeouts (Squid
+	//   defaults to ~60s) to avoid grabbing stale pooled connections on warm
+	//   Lambda invocations.
+	// - ResponseHeaderTimeout bounds how long we wait for the proxy/server to
+	//   start responding, preventing zombie connections.
 	baseTransport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
 		TLSClientConfig:       t.tlsClientConfig,
 	}
 	err := http2.ConfigureTransport(baseTransport)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -169,7 +169,7 @@ github.com/cenkalti/backoff/v5
 # github.com/cespare/xxhash/v2 v2.3.0
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/conductorone/baton-sdk v0.8.17
+# github.com/conductorone/baton-sdk v0.8.18
 ## explicit; go 1.25.2
 github.com/conductorone/baton-sdk/internal/connector
 github.com/conductorone/baton-sdk/pb/c1/c1z/v1


### PR DESCRIPTION
## Summary
- Updates baton-sdk from v0.8.17 to v0.8.18

## Test plan
- [x] Build passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)