### PR TITLE
fix: normalize resource arg keys to camelCase (CXP-467)

### DIFF
--- a/vendor/github.com/conductorone/baton-sdk/pkg/actions/args.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/actions/args.go
@@ -70,8 +70,8 @@ func GetBoolArg(args *structpb.Struct, key string) (bool, bool) {
 }
 
 // GetResourceIDArg extracts a ResourceId from the args struct by key.
-// The value is expected to be a struct with "resource_type_id" and "resource_id" fields
-// (as stored by ResourceField). Returns the ResourceId and true if found, nil and false otherwise.
+// The value is expected to be a struct with "resourceTypeId" and "resourceId" fields.
+// Returns the ResourceId and true if found, nil and false otherwise.
 func GetResourceIDArg(args *structpb.Struct, key string) (*v2.ResourceId, bool) {
 	if args == nil || args.Fields == nil {
 		return nil, false
@@ -87,23 +87,14 @@ func GetResourceIDArg(args *structpb.Struct, key string) (*v2.ResourceId, bool) 
 		return nil, false
 	}
 
-	// Try to get resource_type_id and resource_id fields
-	resourceTypeID, ok := GetStringArg(structValue.StructValue, "resource_type_id")
+	resourceTypeID, ok := GetStringArg(structValue.StructValue, "resourceTypeId")
 	if !ok {
-		// Also try resource_type as an alternative
-		resourceTypeID, ok = GetStringArg(structValue.StructValue, "resource_type")
-		if !ok {
-			return nil, false
-		}
+		return nil, false
 	}
 
-	resourceID, ok := GetStringArg(structValue.StructValue, "resource_id")
+	resourceID, ok := GetStringArg(structValue.StructValue, "resourceId")
 	if !ok {
-		// Also try resource as an alternative
-		resourceID, ok = GetStringArg(structValue.StructValue, "resource")
-		if !ok {
-			return nil, false
-		}
+		return nil, false
 	}
 
 	return &v2.ResourceId{
@@ -214,23 +205,14 @@ func GetResourceIdListArg(args *structpb.Struct, key string) ([]*v2.ResourceId, 
 		if !ok {
 			return nil, false
 		}
-		// Try to get resource_type_id and resource_id fields
-		resourceTypeID, ok := GetStringArg(structValue.StructValue, "resource_type_id")
+		resourceTypeID, ok := GetStringArg(structValue.StructValue, "resourceTypeId")
 		if !ok {
-			// Also try resource_type as an alternative
-			resourceTypeID, ok = GetStringArg(structValue.StructValue, "resource_type")
-			if !ok {
-				return nil, false
-			}
+			return nil, false
 		}
 
-		resourceID, ok := GetStringArg(structValue.StructValue, "resource_id")
+		resourceID, ok := GetStringArg(structValue.StructValue, "resourceId")
 		if !ok {
-			// Also try resource as an alternative
-			resourceID, ok = GetStringArg(structValue.StructValue, "resource")
-			if !ok {
-				return nil, false
-			}
+			return nil, false
 		}
 		resourceIDs = append(resourceIDs, &v2.ResourceId{
 			ResourceType: resourceTypeID,


### PR DESCRIPTION
## Summary

- `GetResourceIDArg` and `GetResourceIdListArg` in `baton-sdk/pkg/actions/args.go` previously only accepted snake_case keys (`resource_type_id`, `resource_id`), causing the `userMembers` field to be silently dropped when the C1 Automations UI serializes resource picker values in camelCase
- Replaced all snake_case key lookups with camelCase (`resourceTypeId`, `resourceId`) as the single canonical format
- CLI users passing snake_case will now receive a clear error (`required argument X is missing or invalid`) rather than silent failure

## Test plan

- [ ] Trigger `create` group action from C1 Automations UI with a user selected via resource picker — group should be created with the member applied
- [ ] Verify CLI usage with camelCase keys still works: `{"name": "my-group", "userMembers": [{"resourceTypeId": "user", "resourceId": "<okta-user-id>"}]}`
- [ ] Verify CLI usage with snake_case keys now returns an error

Fixes CXP-467

🤖 Generated with [Claude Code](https://claude.com/claude-code)