### PR TITLE
CXH-717: Expose Okta group type in group profile

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -25,6 +25,18 @@ sidebarTitle: "Okta"
 The standard roles **Workflows Administrator**, **Access Certifications Administrator**, and **Access Requests Administrator** appear as Custom Roles in C1. Enable **Sync Custom Roles** to see them. The Okta API returns these roles through the same endpoint as custom roles.
 </Note>
 
+<Note>
+Synced groups expose their source type on the resource profile as **`type`**. Today, Okta defines three values:
+
+- **`OKTA_GROUP`** — a group created and managed natively in Okta.
+- **`APP_GROUP`** — a push group created when a SCIM-integrated app mirrors its groups into Okta.
+- **`BUILT_IN`** — a system group provided by Okta (these are also marked immutable).
+
+The connector surfaces whatever value Okta returns, so any future group types Okta introduces will appear here verbatim.
+
+Use this attribute in policies and access profiles to verify that bindings and grants reference the intended kind of group, especially when an Okta-native group and an app push group share the same name.
+</Note>
+
 The Okta connector supports [automatic account provisioning](/product/admin/account-provisioning).
 
 This connector does not support account deprovisioning. You must deprovision accounts directly in Okta.

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -26,8 +26,8 @@ var disableUser = &v2.BatonActionSchema{
 	},
 	ReturnTypes: []*config.Field{
 		{
-			Name:        "success",
-			DisplayName: "Success",
+			Name:        actionResultSuccess,
+			DisplayName: actionResultSuccessDisplay,
 			Field:       &config.Field_BoolField{},
 		},
 		{
@@ -54,8 +54,8 @@ var enableUser = &v2.BatonActionSchema{
 	},
 	ReturnTypes: []*config.Field{
 		{
-			Name:        "success",
-			DisplayName: "Success",
+			Name:        actionResultSuccess,
+			DisplayName: actionResultSuccessDisplay,
 			Field:       &config.Field_BoolField{},
 		},
 		{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -69,10 +69,10 @@ var (
 		Annotations: v1AnnotationsForResourceType("custom-role", false),
 	}
 	resourceTypeUser = &v2.ResourceType{
-		Id:          "user",
+		Id:          userResourceTypeID,
 		DisplayName: "User",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
-		Annotations: v1AnnotationsForResourceType("user", true),
+		Annotations: v1AnnotationsForResourceType(userResourceTypeID, true),
 	}
 	resourceTypeGroup = &v2.ResourceType{
 		Id:          "group",
@@ -216,7 +216,7 @@ func (c *Okta) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 					Placeholder: "Email",
 					Order:       3,
 				},
-				"login": {
+				profileFieldLogin: {
 					DisplayName: "Login",
 					Required:    false,
 					Description: "This login will be used as the login for the user. Email will be used if login is not present.",

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -390,9 +390,9 @@ func (o *groupResourceType) groupResource(ctx context.Context, group *okta.Group
 
 func (o *groupResourceType) groupTrait(ctx context.Context, group *okta.Group) (*v2.GroupTrait, error) {
 	profileMap := map[string]interface{}{
-		"description":       group.Profile.Description,
-		"name":              group.Profile.Name,
-		groupTypeProfileKey: group.Type,
+		profileFieldDescription: group.Profile.Description,
+		profileFieldName:        group.Profile.Name,
+		groupTypeProfileKey:     group.Type,
 	}
 
 	if userCount, exists := getGroupUserCount(group); exists {
@@ -589,7 +589,7 @@ func (o *groupResourceType) registerModifyGroupAction(ctx context.Context, regis
 				IsRequired:  true,
 			},
 			{
-				Name:        "name",
+				Name:        profileFieldName,
 				DisplayName: "Group Name",
 				Description: "The new name for the group.",
 				Field: &config.Field_StringField{
@@ -603,7 +603,7 @@ func (o *groupResourceType) registerModifyGroupAction(ctx context.Context, regis
 				IsRequired: false,
 			},
 			{
-				Name:        "description",
+				Name:        profileFieldDescription,
 				DisplayName: "Description",
 				Description: "The new description for the group.",
 				Field:       &config.Field_StringField{},
@@ -611,7 +611,7 @@ func (o *groupResourceType) registerModifyGroupAction(ctx context.Context, regis
 			},
 		},
 		ReturnTypes: []*config.Field{
-			{Name: "success", DisplayName: "Success", Field: &config.Field_BoolField{}},
+			{Name: actionResultSuccess, DisplayName: actionResultSuccessDisplay, Field: &config.Field_BoolField{}},
 			{Name: "resource", DisplayName: "Updated Group", Field: &config.Field_ResourceField{}},
 		},
 		ActionType: []v2.ActionType{v2.ActionType_ACTION_TYPE_UNSPECIFIED},
@@ -626,8 +626,8 @@ func (o *groupResourceType) handleModifyGroupAction(ctx context.Context, args *s
 		return nil, nil, err
 	}
 
-	newName, hasName := actions.GetStringArg(args, "name")
-	newDescription, hasDescription := actions.GetStringArg(args, "description")
+	newName, hasName := actions.GetStringArg(args, profileFieldName)
+	newDescription, hasDescription := actions.GetStringArg(args, profileFieldDescription)
 
 	if !hasName && !hasDescription {
 		return nil, nil, fmt.Errorf("okta-connectorv2: at least one of name or description must be provided")
@@ -689,7 +689,7 @@ func (o *groupResourceType) handleModifyGroupAction(ctx context.Context, args *s
 		defer updateResp.Body.Close()
 	}
 
-	l.Info("updated Okta group", zap.String("groupId", updatedGroup.Id), zap.String("name", profile.Name))
+	l.Info("updated Okta group", zap.String("groupId", updatedGroup.Id), zap.String(profileFieldName, profile.Name))
 
 	resource, err := o.groupResource(ctx, updatedGroup)
 	if err != nil {
@@ -709,7 +709,7 @@ func (o *groupResourceType) registerCreateGroupAction(ctx context.Context, regis
 		Name: "create",
 		Arguments: []*config.Field{
 			{
-				Name:        "name",
+				Name:        profileFieldName,
 				DisplayName: "Group Name",
 				Description: "The name of the Okta group to create",
 				Field: &config.Field_StringField{
@@ -723,7 +723,7 @@ func (o *groupResourceType) registerCreateGroupAction(ctx context.Context, regis
 				IsRequired: true,
 			},
 			{
-				Name:        "description",
+				Name:        profileFieldDescription,
 				DisplayName: "Description",
 				Description: "Description of the group",
 				Field:       &config.Field_StringField{},
@@ -744,7 +744,7 @@ func (o *groupResourceType) registerCreateGroupAction(ctx context.Context, regis
 			},
 		},
 		ReturnTypes: []*config.Field{
-			{Name: "success", DisplayName: "Success", Field: &config.Field_BoolField{}},
+			{Name: actionResultSuccess, DisplayName: actionResultSuccessDisplay, Field: &config.Field_BoolField{}},
 			{Name: "resource", DisplayName: "Created Group", Field: &config.Field_ResourceField{}},
 		},
 		ActionType: []v2.ActionType{v2.ActionType_ACTION_TYPE_RESOURCE_CREATE},
@@ -754,12 +754,12 @@ func (o *groupResourceType) registerCreateGroupAction(ctx context.Context, regis
 func (o *groupResourceType) handleCreateGroupAction(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
-	groupName, err := actions.RequireStringArg(args, "name")
+	groupName, err := actions.RequireStringArg(args, profileFieldName)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	description, _ := actions.GetStringArg(args, "description")
+	description, _ := actions.GetStringArg(args, profileFieldDescription)
 
 	newGroup := okta.Group{
 		Profile: &okta.GroupProfile{
@@ -773,14 +773,14 @@ func (o *groupResourceType) handleCreateGroupAction(ctx context.Context, args *s
 		if resp != nil {
 			defer resp.Body.Close()
 		}
-		l.Error("failed to create Okta group", zap.Error(err), zap.String("name", groupName))
+		l.Error("failed to create Okta group", zap.Error(err), zap.String(profileFieldName, groupName))
 		return nil, nil, fmt.Errorf("okta-connectorv2: failed to create group: %w", err)
 	}
 	if resp != nil {
 		defer resp.Body.Close()
 	}
 
-	l.Info("created Okta group", zap.String("groupId", createdGroup.Id), zap.String("name", groupName))
+	l.Info("created Okta group", zap.String("groupId", createdGroup.Id), zap.String(profileFieldName, groupName))
 
 	userMemberIDs, ok := actions.GetResourceIdListArg(args, "userMembers")
 	if ok {

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -29,8 +29,10 @@ var _ connectorbuilder.ResourceDeleterV2Limited = (*groupResourceType)(nil)
 
 const membershipUpdatedField = "lastMembershipUpdated"
 const usersCountProfileKey = "users_count"
+const groupTypeProfileKey = "type"
 const builtInGroupType = "BUILT_IN"
 const appGroupType = "APP_GROUP"
+const oktaGroupType = "OKTA_GROUP"
 const apiPathGetGroupFmt = "/api/v1/groups/%s"
 
 type groupResourceType struct {
@@ -388,8 +390,9 @@ func (o *groupResourceType) groupResource(ctx context.Context, group *okta.Group
 
 func (o *groupResourceType) groupTrait(ctx context.Context, group *okta.Group) (*v2.GroupTrait, error) {
 	profileMap := map[string]interface{}{
-		"description": group.Profile.Description,
-		"name":        group.Profile.Name,
+		"description":       group.Profile.Description,
+		"name":              group.Profile.Name,
+		groupTypeProfileKey: group.Type,
 	}
 
 	if userCount, exists := getGroupUserCount(group); exists {

--- a/pkg/connector/group_test.go
+++ b/pkg/connector/group_test.go
@@ -1,0 +1,60 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func TestGroupTrait_TypeProfileKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		oktaType string
+		want     string
+	}{
+		{name: "okta-native group", oktaType: oktaGroupType, want: "OKTA_GROUP"},
+		{name: "app push group", oktaType: appGroupType, want: "APP_GROUP"},
+		{name: "built-in group", oktaType: builtInGroupType, want: "BUILT_IN"},
+		{name: "unknown future value passes through verbatim", oktaType: "FUTURE_TYPE", want: "FUTURE_TYPE"},
+		{name: "empty type passes through as empty", oktaType: "", want: ""},
+	}
+
+	o := &groupResourceType{}
+	ctx := context.Background()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			group := &okta.Group{
+				Id:   "00g1abc2def3GHI4jk5",
+				Type: tc.oktaType,
+				Profile: &okta.GroupProfile{
+					Name:        "test-group",
+					Description: "test description",
+				},
+			}
+
+			trait, err := o.groupTrait(ctx, group)
+			if err != nil {
+				t.Fatalf("groupTrait returned error: %v", err)
+			}
+			if trait == nil || trait.Profile == nil {
+				t.Fatalf("groupTrait returned nil trait or profile")
+			}
+
+			got, ok := trait.Profile.Fields[groupTypeProfileKey]
+			if !ok {
+				t.Fatalf("profile is missing %q key; fields=%v", groupTypeProfileKey, trait.Profile.Fields)
+			}
+			if got.GetStringValue() != tc.want {
+				t.Errorf("profile[%q] = %q, want %q", groupTypeProfileKey, got.GetStringValue(), tc.want)
+			}
+
+			for _, key := range []string{"name", "description"} {
+				if _, ok := trait.Profile.Fields[key]; !ok {
+					t.Errorf("profile is missing pre-existing %q key", key)
+				}
+			}
+		})
+	}
+}

--- a/pkg/connector/group_test.go
+++ b/pkg/connector/group_test.go
@@ -50,7 +50,7 @@ func TestGroupTrait_TypeProfileKey(t *testing.T) {
 				t.Errorf("profile[%q] = %q, want %q", groupTypeProfileKey, got.GetStringValue(), tc.want)
 			}
 
-			for _, key := range []string{"name", "description"} {
+			for _, key := range []string{profileFieldName, profileFieldDescription} {
 				if _, ok := trait.Profile.Fields[key]; !ok {
 					t.Errorf("profile is missing pre-existing %q key", key)
 				}

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -167,7 +167,7 @@ func convertNotFoundError(err error, message string) error {
 // The message parameter provides additional context about the action result.
 func createSuccessResponse(message string) *structpb.Struct {
 	fields := map[string]*structpb.Value{
-		"success": structpb.NewBoolValue(true),
+		actionResultSuccess: structpb.NewBoolValue(true),
 	}
 	if message != "" {
 		fields["message"] = structpb.NewStringValue(message)

--- a/pkg/connector/profile_keys.go
+++ b/pkg/connector/profile_keys.go
@@ -1,0 +1,15 @@
+package connector
+
+const (
+	profileFieldName        = "name"
+	profileFieldDescription = "description"
+	profileFieldLabel       = "label"
+	profileFieldLogin       = "login"
+)
+
+const (
+	actionResultSuccess        = "success"
+	actionResultSuccessDisplay = "Success"
+)
+
+const userResourceTypeID = "user"

--- a/pkg/connector/resource_sets.go
+++ b/pkg/connector/resource_sets.go
@@ -42,9 +42,9 @@ func (rs *resourceSetsResourceType) ResourceType(ctx context.Context) *v2.Resour
 
 func resourceSetsResource(ctx context.Context, rs *ResourceSets, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"id":          rs.ID,
-		"label":       rs.Label,
-		"description": rs.Description,
+		"id":                    rs.ID,
+		profileFieldLabel:       rs.Label,
+		profileFieldDescription: rs.Description,
 	}
 
 	return sdkResource.NewResource(
@@ -60,9 +60,9 @@ func resourceSetsResource(ctx context.Context, rs *ResourceSets, parentResourceI
 
 func resourceSetResource(ctx context.Context, rs *oktav5.ResourceSet, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"id":          *rs.Id,
-		"label":       *rs.Label,
-		"description": *rs.Description,
+		"id":                    *rs.Id,
+		profileFieldLabel:       *rs.Label,
+		profileFieldDescription: *rs.Description,
 	}
 
 	return sdkResource.NewResource(

--- a/pkg/connector/resource_sets_bindings.go
+++ b/pkg/connector/resource_sets_bindings.go
@@ -41,9 +41,9 @@ func (rsb *resourceSetsBindingsResourceType) ResourceType(ctx context.Context) *
 
 func resourceSetsBindingsResource(ctx context.Context, rs *ResourceSets, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"id":          rs.ID,
-		"label":       rs.Label,
-		"description": rs.Description,
+		"id":                    rs.ID,
+		profileFieldLabel:       rs.Label,
+		profileFieldDescription: rs.Description,
 	}
 
 	return sdkResource.NewResource(
@@ -57,9 +57,9 @@ func resourceSetsBindingsResource(ctx context.Context, rs *ResourceSets, parentR
 
 func resourceSetBindingsResource(ctx context.Context, rs *oktav5.ResourceSet, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"id":          rs.GetId(),
-		"label":       rs.GetLabel(),
-		"description": rs.GetDescription(),
+		"id":                    rs.GetId(),
+		profileFieldLabel:       rs.GetLabel(),
+		profileFieldDescription: rs.GetDescription(),
 	}
 
 	return sdkResource.NewResource(

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -381,9 +381,9 @@ func roleResource(ctx context.Context, role *okta.Role, ctype *v2.ResourceType) 
 	}
 
 	profile := map[string]interface{}{
-		"id":    role.Id,
-		"label": role.Label,
-		"type":  role.Type,
+		"id":              role.Id,
+		profileFieldLabel: role.Label,
+		"type":            role.Type,
 	}
 
 	return sdkResource.NewRoleResource(

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -120,7 +120,7 @@ func extractEmailsFromUserProfile(user *okta.User) []string {
 	}
 
 	// Check if login field contains an email address
-	if login, ok := oktaProfile["login"].(string); ok && login != "" {
+	if login, ok := oktaProfile[profileFieldLogin].(string); ok && login != "" {
 		if strings.Contains(login, "@") {
 			userEmails = append(userEmails, login)
 		}
@@ -156,7 +156,7 @@ func extractEmailsFromAppUserProfile(appUser *okta.AppUser) []string {
 	}
 
 	// Check if login field contains an email address
-	if login, ok := oktaProfile["login"].(string); ok && login != "" {
+	if login, ok := oktaProfile[profileFieldLogin].(string); ok && login != "" {
 		if strings.Contains(login, "@") {
 			userEmails = append(userEmails, login)
 		}
@@ -306,7 +306,7 @@ func userResource(ctx context.Context, user *okta.User, skipSecondaryEmails bool
 			if id, ok := profileValue.(string); ok {
 				employeeIDs.Add(id)
 			}
-		case "login":
+		case profileFieldLogin:
 			if login, ok := profileValue.(string); ok {
 				// If possible, calculate shortname alias from login
 				splitLogin := strings.Split(login, "@")
@@ -451,16 +451,16 @@ func getUserProfile(accountInfo *v2.AccountInfo) (*okta.UserProfile, error) {
 		return nil, fmt.Errorf("okta-connectorv2: missing email in account info")
 	}
 
-	login, ok := pMap["login"]
+	login, ok := pMap[profileFieldLogin]
 	if !ok {
 		login = email
 	}
 
 	return &okta.UserProfile{
-		"firstName": firstName,
-		"lastName":  lastName,
-		"email":     email,
-		"login":     login,
+		"firstName":       firstName,
+		"lastName":        lastName,
+		"email":           email,
+		profileFieldLogin: login,
 	}, nil
 }
 


### PR DESCRIPTION
Synced Okta groups now expose their source type (Okta-native, app push, or built-in) on the resource profile, so policies and access profiles can distinguish between groups that share a name.