### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -217,7 +217,7 @@ Copy and save the new API token.
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ### (Alternative) Set up an OAuth 2.0 OIDC app
 
@@ -338,7 +338,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Okta connector is now pulling access data into C1.
+**Done.** Your Okta connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -466,7 +466,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Okta connector is now pulling access data into C1.
+**Done.** Your Okta connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site.

- Restore `**Done.**` closing phrase (replaces `**That's it!**`) — 3 instances

These corrections prevent the sync bot from reintroducing regressions on future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)