### PR TITLE
chore: update baton-sdk to v0.15.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,13 @@ module github.com/conductorone/baton-okta
 go 1.25.2
 
 require (
-	github.com/conductorone/baton-sdk v0.15.5
+	github.com/conductorone/baton-sdk v0.15.6
+	github.com/conductorone/dpop v0.2.6
+	github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.5
 	github.com/conductorone/okta-sdk-golang/v5 v5.0.6-conductorone
 	github.com/deckarep/golang-set/v2 v2.9.0
 	github.com/ennyjfrick/ruleguard-logfatal v0.0.2
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/okta/okta-sdk-golang/v2 v2.20.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
@@ -32,14 +35,11 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
-	github.com/conductorone/dpop v0.2.6 // indirect
 	github.com/conductorone/dpop/integrations/dpop_grpc v0.2.4 // indirect
-	github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
@@ -112,7 +112,7 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
@@ -148,7 +148,7 @@ require (
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b h1:VXvSNzmr8hMj8
 github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
-github.com/conductorone/baton-sdk v0.15.5 h1:n5x2wduKILDzYTCtqj1Z5Xp9ItoWt2fgrWo16GLdIlk=
-github.com/conductorone/baton-sdk v0.15.5/go.mod h1:xacgmef9cM4dUTdvGN3Qip6fwkRbciqtaZMi5iWnjsY=
+github.com/conductorone/baton-sdk v0.15.6 h1:3SGTpPiebKiisgn7+fl5VLlnodkBzmi//1YWsxa1zPU=
+github.com/conductorone/baton-sdk v0.15.6/go.mod h1:xacgmef9cM4dUTdvGN3Qip6fwkRbciqtaZMi5iWnjsY=
 github.com/conductorone/dpop v0.2.6 h1:fakwai/Xm2b/fcDUwJN41WtcSI/2UhQOyRIVvnnrrNA=
 github.com/conductorone/dpop v0.2.6/go.mod h1:gyo8TtzB9SCFCsjsICH4IaLZ7y64CcrDXMOPBwfq/3s=
 github.com/conductorone/dpop/integrations/dpop_grpc v0.2.4 h1:lYxYi9/WTSL9sE96CO0QF2BY3kehs8dTTApI134TGCA=

--- a/vendor/github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/adapter.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/adapter.go
@@ -166,22 +166,50 @@ func (a *Adapter) ResumeSync(ctx context.Context, syncType connectorstore.SyncTy
 		return "", err
 	}
 	a.current = syncRunState{
-		syncID:    syncID,
-		syncType:  existing.GetType(),
-		parentID:  existing.GetParentSyncId(),
+		syncID:   syncID,
+		syncType: existing.GetType(),
+		parentID: existing.GetParentSyncId(),
+		// Load the persisted checkpoint token back into the in-memory
+		// cache. CurrentSyncStep reads a.current.step directly, so
+		// omitting this makes a resumed sync report step "" and the
+		// syncer's state.Unmarshal("") restarts the FSM from InitOp —
+		// i.e. a full sync every activity window. CheckpointSync/EndSync
+		// round-trip SyncToken via the SyncRunRecord; resume must too.
+		step:      existing.GetSyncToken(),
 		startedAt: existing.GetStartedAt().AsTime(),
 	}
 	return syncID, nil
 }
 
-// StartOrResumeSync resumes if syncID-like state exists for the given
-// type, else starts a new sync. Returns (id, started_new, err).
+// StartOrResumeSync resumes an existing sync if one is resumable, else
+// starts a new sync. Returns (id, started_new, err).
+//
+// Resume precedence mirrors SQLite's StartOrResumeSync→ResumeSync
+// cascade (pkg/dotc1z/sync_runs.go):
+//
+//  1. A caller-supplied syncID that names an existing sync_run.
+//  2. With an empty syncID, the latest in-progress (not-yet-ended)
+//     sync of the requested type started within the last week — the
+//     same predicate as Engine.LatestUnfinishedSyncRecord. This is the
+//     path the syncer drives across activity windows: it calls
+//     StartOrResumeSync(ctx, syncType, "") with no id, expecting an
+//     interrupted sync to resume where it checkpointed. Without this,
+//     every window started a brand-new sync (wiping prior data via
+//     ResetForNewSync and resetting the FSM to InitOp), so any sync
+//     exceeding one window never finished.
+//
+// Only when nothing is resumable do we start a new sync.
 func (a *Adapter) StartOrResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, bool, error) {
 	if syncID != "" {
 		if _, err := a.engine.GetSyncRunRecord(ctx, syncID); err == nil {
 			id, err := a.ResumeSync(ctx, syncType, syncID)
 			return id, false, err
 		}
+	} else if rec, err := a.engine.LatestUnfinishedSyncRecord(ctx, syncTypeFilterFromConnectorstore(syncType)); err != nil {
+		return "", false, err
+	} else if rec != nil {
+		id, err := a.ResumeSync(ctx, syncType, rec.GetSyncId())
+		return id, false, err
 	}
 	id, err := a.StartNewSync(ctx, syncType, "")
 	return id, true, err
@@ -196,7 +224,24 @@ func (a *Adapter) SetCurrentSync(ctx context.Context, syncID string) error {
 	if err := a.engine.SetCurrentSync(syncID); err != nil {
 		return err
 	}
-	a.current.syncID = syncID
+	// Rehydrate the in-memory cache from the persisted record so
+	// CurrentSyncStep reflects the on-disk SyncToken after a rebind —
+	// the same reason ResumeSync loads step. SQLite's CurrentSyncStep
+	// re-reads the sync_runs row on every call and so is immune; Pebble
+	// caches a.current.step, so a rebind that doesn't refresh it would
+	// report a stale (or empty) step and reset the FSM. Best-effort: a
+	// missing/unreadable record clears the cached step rather than
+	// leaving a value from a previously-bound sync.
+	a.current = syncRunState{syncID: syncID}
+	if rec, err := a.engine.GetSyncRunRecord(ctx, syncID); err == nil && rec != nil {
+		a.current = syncRunState{
+			syncID:    syncID,
+			syncType:  rec.GetType(),
+			parentID:  rec.GetParentSyncId(),
+			step:      rec.GetSyncToken(),
+			startedAt: rec.GetStartedAt().AsTime(),
+		}
+	}
 	return nil
 }
 

--- a/vendor/github.com/conductorone/baton-sdk/pkg/sdk/version.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/sdk/version.go
@@ -1,3 +1,3 @@
 package sdk
 
-const Version = "v0.15.4"
+const Version = "v0.15.5"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -273,7 +273,7 @@ github.com/cockroachdb/swiss
 # github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06
 ## explicit; go 1.19
 github.com/cockroachdb/tokenbucket
-# github.com/conductorone/baton-sdk v0.15.5
+# github.com/conductorone/baton-sdk v0.15.6
 ## explicit; go 1.25.2
 github.com/conductorone/baton-sdk/internal/connector
 github.com/conductorone/baton-sdk/pb/c1/c1z/v1


### PR DESCRIPTION
## Summary

Updates the `github.com/conductorone/baton-sdk` dependency from **v0.15.5** to **v0.15.6** (the newly released version).

- Bumped `baton-sdk` to v0.15.6 via `go get`
- Ran `go mod tidy`
- Ran `go mod vendor`

`go mod tidy` also recalculated the direct/indirect status of a few dependencies that the recently-added OAuth 2.0 DPoP support (#172) now references directly: `github.com/conductorone/dpop`, `github.com/conductorone/dpop/integrations/dpop_oauth2`, `github.com/go-jose/go-jose/v4`, `github.com/google/uuid`, and `golang.org/x/sync` moved from `// indirect` to direct requires.

Release notes: https://github.com/ConductorOne/baton-sdk/releases/tag/v0.15.6

## Testing

- `go build ./cmd/baton-*` — passes
- `go test ./...` — all packages pass

## Live Preview

N/A — this is a CLI Baton connector with no web service; `get_endpoints` returned no exposed endpoints.

## Follow-up / Caveats

None.
