### PR TITLE
CXH-1910: change okta-private-key field to FileUploadField

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -137,7 +137,11 @@
       "stringField": {
         "rules": {
           "isRequired": true
-        }
+        },
+        "type": "STRING_FIELD_TYPE_FILE_UPLOAD",
+        "allowedExtensions": [
+          ".pem"
+        ]
       }
     },
     {

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -339,7 +339,7 @@ Enter your Okta domain (the URL of your Okta instance is `<YOUR DOMAIN>.okta.com
 Enter your credentials:
 
    - For **API Token**: paste your API token into the **API token** field.
-   - For **OAuth 2.0 Private Key**: enter your **Okta Client ID**, **Okta Private Key ID**, and paste the **Okta Private Key** (PEM-encoded).
+   - For **OAuth 2.0 Private Key**: enter your **Okta Client ID**, **Okta Private Key ID**, and upload the **Okta Private Key** (a `.pem` file).
 </Step>
 <Step>
 **Optional.** If desired, click the checkbox to **Sync custom roles**.

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,7 +7,7 @@ type Okta struct {
 	Domain string `mapstructure:"domain"`
 	ApiToken string `mapstructure:"api-token"`
 	OktaClientId string `mapstructure:"okta-client-id"`
-	OktaPrivateKey string `mapstructure:"okta-private-key"`
+	OktaPrivateKey []byte `mapstructure:"okta-private-key"`
 	OktaPrivateKeyId string `mapstructure:"okta-private-key-id"`
 	SyncInactiveApps bool `mapstructure:"sync-inactive-apps"`
 	Cache bool `mapstructure:"cache"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,8 @@ var (
 		field.WithRequired(true),
 		field.WithDescription("The Okta Private Key ID"),
 	)
-	oktaPrivateKey = field.StringField("okta-private-key",
+	oktaPrivateKey = field.FileUploadField("okta-private-key",
+		[]string{".pem"},
 		field.WithDisplayName("Okta Private Key"),
 		field.WithRequired(true),
 		field.WithDescription("The Okta Private Key (PEM-encoded)"),

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -357,7 +357,7 @@ func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorb
 		dpopClient, err := oktaauth.NewDPoPHTTPClient(ctx, oktaauth.Config{
 			Domain:        cc.Domain,
 			ClientID:      cc.OktaClientId,
-			PrivateKeyPEM: cc.OktaPrivateKey,
+			PrivateKeyPEM: string(cc.OktaPrivateKey),
 			PrivateKeyID:  cc.OktaPrivateKeyId,
 			Scopes:        scopes,
 		}, client)


### PR DESCRIPTION
## Summary

- Changed `okta-private-key` config field from `StringField` to `FileUploadField` (accepting `.pem` files)
- Updated `conf.gen.go` (regenerated): `OktaPrivateKey` is now `[]byte` instead of `string`
- Cast `cc.OktaPrivateKey` to `string` when passing to `oktaauth.Config.PrivateKeyPEM`
- Regenerated `config_schema.json` to reflect the new field type

## Test plan

- [x] `make` builds cleanly
- [x] `make lint` passes with 0 issues
- [x] `config_schema.json` regenerated with correct `STRING_FIELD_TYPE_FILE_UPLOAD` type and `.pem` allowed extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)