### PR TITLE
fix: normalize escaped newlines in private key PEM string

### DIFF
--- a/pkg/oktaauth/oktaauth.go
+++ b/pkg/oktaauth/oktaauth.go
@@ -111,6 +111,7 @@ func transportOrDefault(c *http.Client) http.RoundTripper {
 }
 
 func parseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
+	pemStr = strings.ReplaceAll(pemStr, `\n`, "\n")
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {
 		return nil, errors.New("no PEM block found")


### PR DESCRIPTION
## Summary
- Normalizes escaped `\n` sequences in the private key PEM string before decoding, so keys provided as a single-line string (e.g., from environment variables or config fields) are parsed correctly.

## Test plan
- [ ] Configure connector with a private key where newlines are literal `\n` escape sequences (e.g., copied from an env var or JSON field)
- [ ] Verify sync completes without "no PEM block found" error
- [ ] Verify sync still works with a properly formatted multi-line PEM key

🤖 Generated with [Claude Code](https://claude.com/claude-code)