### PR TITLE
chore: upgrade baton-sdk to v0.15.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/conductorone/baton-okta
 go 1.25.2
 
 require (
-	github.com/conductorone/baton-sdk v0.15.7
+	github.com/conductorone/baton-sdk v0.15.8
 	github.com/conductorone/dpop v0.2.6
 	github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.5
 	github.com/conductorone/okta-sdk-golang/v5 v5.0.6-conductorone

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b h1:VXvSNzmr8hMj8
 github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
-github.com/conductorone/baton-sdk v0.15.7 h1:bLji/N+9w4GSueb5Kg6fz+7bH382ciiwyqa4wfJjVcs=
-github.com/conductorone/baton-sdk v0.15.7/go.mod h1:xacgmef9cM4dUTdvGN3Qip6fwkRbciqtaZMi5iWnjsY=
+github.com/conductorone/baton-sdk v0.15.8 h1:a1t62lZ6/HZXe2/uSvyjg9A7n8wm+eEDQ7TZbWsBVUA=
+github.com/conductorone/baton-sdk v0.15.8/go.mod h1:xacgmef9cM4dUTdvGN3Qip6fwkRbciqtaZMi5iWnjsY=
 github.com/conductorone/dpop v0.2.6 h1:fakwai/Xm2b/fcDUwJN41WtcSI/2UhQOyRIVvnnrrNA=
 github.com/conductorone/dpop v0.2.6/go.mod h1:gyo8TtzB9SCFCsjsICH4IaLZ7y64CcrDXMOPBwfq/3s=
 github.com/conductorone/dpop/integrations/dpop_grpc v0.2.4 h1:lYxYi9/WTSL9sE96CO0QF2BY3kehs8dTTApI134TGCA=

--- a/vendor/github.com/conductorone/baton-sdk/pkg/lambda/grpc/config/config.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/lambda/grpc/config/config.go
@@ -90,6 +90,7 @@ func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (g
 	opts := []dpop_oauth.TokenSourceOption{
 		dpop_oauth.WithRequestOption(dpop_oauth.WithCustomMarshaler(idAttMarshaller.Marshal)),
 		dpop_oauth.WithHTTPClient(lambdaHTTPClient(tlsConfig)),
+		dpop_oauth.WithNonceStore(dpop_oauth.NewNonceStore()), // satisfy use_dpop_nonce
 	}
 	tokenSource, err := dpop_oauth.NewTokenSource(proofer, tokenURL, clientID, clientSecretJWK, opts...)
 	if err != nil {

--- a/vendor/github.com/conductorone/baton-sdk/pkg/sdk/version.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/sdk/version.go
@@ -1,3 +1,3 @@
 package sdk
 
-const Version = "v0.15.6"
+const Version = "v0.15.7"

--- a/vendor/github.com/conductorone/baton-sdk/pkg/sync/syncer.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/sync/syncer.go
@@ -2907,7 +2907,7 @@ func NewSyncer(ctx context.Context, c types.ConnectorClient, opts ...SyncOpt) (S
 	s.wireCountsDBSizeProvider()
 
 	if s.externalResourceC1ZPath != "" {
-		externalC1ZReader, err := dotc1z.NewExternalC1FileReader(ctx, s.tmpDir, s.externalResourceC1ZPath)
+		externalC1ZReader, err := dotc1z.NewStore(ctx, s.externalResourceC1ZPath, dotc1z.WithTmpDir(s.tmpDir), dotc1z.WithReadOnly(true))
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -273,7 +273,7 @@ github.com/cockroachdb/swiss
 # github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06
 ## explicit; go 1.19
 github.com/cockroachdb/tokenbucket
-# github.com/conductorone/baton-sdk v0.15.7
+# github.com/conductorone/baton-sdk v0.15.8
 ## explicit; go 1.25.2
 github.com/conductorone/baton-sdk/internal/connector
 github.com/conductorone/baton-sdk/pb/c1/c1z/v1


### PR DESCRIPTION
## Summary

Upgrades the `github.com/conductorone/baton-sdk` dependency from **v0.15.7** to **v0.15.8** ([release notes](https://github.com/ConductorOne/baton-sdk/releases/tag/v0.15.8)).

Changes:
- `go.mod` / `go.sum` updated to require `baton-sdk v0.15.8`
- Re-ran `go mod tidy` and `go mod vendor` to sync the vendored SDK sources (this repo vendors dependencies)

No connector source changes were required — the upgrade is a clean drop-in.

## Testing

- `go build ./cmd/baton-okta` — succeeds
- `go test ./...` — all packages pass (`pkg/connector`, `pkg/oktaauth` ok)

## Live Preview

Not applicable — `baton-okta` is a CLI connector with no exposed web service (`get_endpoints` returned no endpoints).

## Caveats / Follow-up

- GitHub reported pre-existing Dependabot vulnerabilities on the default branch (1 high, 1 moderate); these are unrelated to this SDK bump.
