### PR TITLE
feat: populate GroupTrait.group_source_type/raw_group_source_type

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -378,10 +378,30 @@ func (o *groupResourceType) groupTrait(ctx context.Context, group *okta.Group) (
 	}
 
 	ret := &v2.GroupTrait{
-		Profile: profile,
+		Profile:            profile,
+		GroupSourceType:    mapOktaGroupSourceType(group.Type),
+		RawGroupSourceType: group.Type,
 	}
 
 	return ret, nil
+}
+
+// mapOktaGroupSourceType maps Okta's group.Type to the C1-normalized source
+// type vocabulary. AD/LDAP-sourced APP_GROUPs (directory_synced) and
+// dynamic/distribution groups have no distinguishing signal in this field
+// alone, so only the baseline 3-way mapping is covered; unknown/empty types
+// map to "" rather than a fabricated classification.
+func mapOktaGroupSourceType(oktaType string) string {
+	switch oktaType {
+	case builtInGroupType:
+		return "built_in"
+	case appGroupType:
+		return "app_imported"
+	case oktaGroupType:
+		return "native"
+	default:
+		return ""
+	}
 }
 
 func getGroupStat(group *okta.Group, statName string) (float64, bool) {
@@ -576,7 +596,7 @@ func (o *groupResourceType) registerModifyGroupAction(ctx context.Context, regis
 				DisplayName: "Description",
 				Description: "The new description for the group.",
 				Field:       &config.Field_StringField{},
-				IsRequired: false,
+				IsRequired:  false,
 			},
 		},
 		ReturnTypes: []*config.Field{

--- a/pkg/connector/group_test.go
+++ b/pkg/connector/group_test.go
@@ -9,15 +9,16 @@ import (
 
 func TestGroupTrait_TypeProfileKey(t *testing.T) {
 	tests := []struct {
-		name     string
-		oktaType string
-		want     string
+		name           string
+		oktaType       string
+		want           string
+		wantSourceType string
 	}{
-		{name: "okta-native group", oktaType: oktaGroupType, want: "OKTA_GROUP"},
-		{name: "app push group", oktaType: appGroupType, want: "APP_GROUP"},
-		{name: "built-in group", oktaType: builtInGroupType, want: "BUILT_IN"},
-		{name: "unknown future value passes through verbatim", oktaType: "FUTURE_TYPE", want: "FUTURE_TYPE"},
-		{name: "empty type passes through as empty", oktaType: "", want: ""},
+		{name: "okta-native group", oktaType: oktaGroupType, want: "OKTA_GROUP", wantSourceType: "native"},
+		{name: "app push group", oktaType: appGroupType, want: "APP_GROUP", wantSourceType: "app_imported"},
+		{name: "built-in group", oktaType: builtInGroupType, want: "BUILT_IN", wantSourceType: "built_in"},
+		{name: "unknown future value passes through verbatim", oktaType: "FUTURE_TYPE", want: "FUTURE_TYPE", wantSourceType: ""},
+		{name: "empty type passes through as empty", oktaType: "", want: "", wantSourceType: ""},
 	}
 
 	o := &groupResourceType{}
@@ -54,6 +55,34 @@ func TestGroupTrait_TypeProfileKey(t *testing.T) {
 				if _, ok := trait.Profile.Fields[key]; !ok {
 					t.Errorf("profile is missing pre-existing %q key", key)
 				}
+			}
+
+			if got := trait.GetRawGroupSourceType(); got != tc.oktaType {
+				t.Errorf("RawGroupSourceType = %q, want %q", got, tc.oktaType)
+			}
+			if got := trait.GetGroupSourceType(); got != tc.wantSourceType {
+				t.Errorf("GroupSourceType = %q, want %q", got, tc.wantSourceType)
+			}
+		})
+	}
+}
+
+func TestMapOktaGroupSourceType(t *testing.T) {
+	tests := []struct {
+		oktaType string
+		want     string
+	}{
+		{oktaType: oktaGroupType, want: "native"},
+		{oktaType: appGroupType, want: "app_imported"},
+		{oktaType: builtInGroupType, want: "built_in"},
+		{oktaType: "FUTURE_TYPE", want: ""},
+		{oktaType: "", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.oktaType, func(t *testing.T) {
+			if got := mapOktaGroupSourceType(tc.oktaType); got != tc.want {
+				t.Errorf("mapOktaGroupSourceType(%q) = %q, want %q", tc.oktaType, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `group.Type` was read only to flag `BUILT_IN` groups as immutable and passed through as a raw `"type"` profile map key; it was never mapped onto `GroupTrait.group_source_type`/`raw_group_source_type` (added in baton-sdk v0.13.1, already present in this repo's current v0.17.0 dependency).
- Adds `mapOktaGroupSourceType()` and sets both typed fields in `groupTrait()`.
- Covers the baseline 3-way mapping: `OKTA_GROUP` → `native`, `APP_GROUP` → `app_imported`, `BUILT_IN` → `built_in`. Unknown/future/empty values map to `""` rather than a guessed classification.
- **Not covered** (follow-up): distinguishing AD/LDAP-sourced `APP_GROUP`s as `directory_synced` needs the `objectClass`/`_embedded.app` data, which `group.Type` alone doesn't carry.

Tracked as [CXH-2009](https://linear.app/ductone/issue/CXH-2009/baton-okta-populate-group-source-typeraw-group-source-type-from) (internal ConductorOne tracker) — this connector-side mapping was the missing link for a wider RFC on propagating resource source-type metadata (IDP group classification) through the C1 stack; the storage/uplift/API side is implemented separately in the `ductone/c1` monorepo and depends on this data actually being populated.

Note: one incidental one-line whitespace diff (`IsRequired: false,` realignment) — the file was already gofmt non-compliant at that line before this change; my editor's on-save format fixed it as a side effect. Happy to drop it if you'd rather keep the diff surgical.

## Test plan

- [x] `go test ./pkg/connector/...` — all pass, including new `TestMapOktaGroupSourceType` and the extended `TestGroupTrait_TypeProfileKey` (now also asserts `GroupSourceType`/`RawGroupSourceType`)
- [x] `golangci-lint run ./pkg/connector/...` — clean
- [x] `go build ./...` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)