### PR TITLE
CXH-1921: add regression test for single-line private-key format

### DIFF
--- a/pkg/oktaauth/oktaauth_test.go
+++ b/pkg/oktaauth/oktaauth_test.go
@@ -323,6 +323,7 @@ func TestParseRSAPrivateKey(t *testing.T) {
 		wantOK    bool
 	}{
 		{name: "PKCS1", pem: pemPKCS1(t, rsaKey), wantOK: true},
+		{name: "PKCS1_literal_newlines", pem: strings.ReplaceAll(pemPKCS1(t, rsaKey), "\n", `\n`), wantOK: true},
 		{name: "PKCS8_RSA", pem: pemPKCS8(t, rsaKey), wantOK: true},
 		{name: "PKCS8_ECDSA", pem: pemPKCS8(t, ecKey), wantErr: "Okta DPoP requires RSA"},
 		{name: "empty", pem: "", wantErr: "no PEM block found"},


### PR DESCRIPTION
The single-line private-key format was already fixed in #178; this adds a regression test so it can't break again.