### PR TITLE
chore: migrate deprecated trait options to resource-level APIs

### DIFF
--- a/pkg/connector/api_token.go
+++ b/pkg/connector/api_token.go
@@ -141,7 +141,6 @@ func apiTokenResource(apiToken *oktav5.ApiToken) (*v2.Resource, error) {
 			BatonResource: false,
 		}),
 		resource.WithSecretLastUsedAt(*apiToken.LastUpdated),
-		resource.WithSecretCreatedAt(*apiToken.Created),
 		resource.WithSecretType(v2.SecretTrait_CREDENTIAL_TYPE_STATIC_SECRET),
 		resource.WithSecretDetail("okta.api_token"),
 	}
@@ -150,6 +149,7 @@ func apiTokenResource(apiToken *oktav5.ApiToken) (*v2.Resource, error) {
 		resourceTypeApiToken,
 		*apiToken.Id,
 		options,
+		resource.WithResourceCreatedAt(*apiToken.Created),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/app.go
+++ b/pkg/connector/app.go
@@ -361,9 +361,9 @@ func appResource(ctx context.Context, app *okta.Application) (*v2.Resource, erro
 		"status": app.Status,
 	}
 	var appTraitOpts []sdkResource.AppTraitOption
-	appTraitOpts = append(appTraitOpts, sdkResource.WithAppProfile(appProfile))
 
 	resourceOpts := []sdkResource.ResourceOption{
+		sdkResource.WithResourceProfile(appProfile),
 		sdkResource.WithAnnotation(&v2.V1Identifier{Id: fmtResourceIdV1(app.Id)}),
 		sdkResource.WithAnnotation(&v2.RawId{Id: app.Id}),
 	}

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -133,11 +133,7 @@ func (o *groupResourceType) Grants(
 
 	switch bag.ResourceTypeID() {
 	case resourceTypeUser.Id:
-		groupTrait, err := sdkResource.GetGroupTrait(resource)
-		if err != nil {
-			return nil, nil, fmt.Errorf("okta-connectorv2: failed to get group trait: %w", err)
-		}
-		usersCount, ok := sdkResource.GetProfileInt64Value(groupTrait.Profile, usersCountProfileKey)
+		usersCount, ok := sdkResource.GetProfileInt64Value(resource.GetProfile(), usersCountProfileKey)
 
 		var annos annotations.Annotations
 		nextPage := ""
@@ -235,11 +231,7 @@ func (o *groupResourceType) Grants(
 				return nil, nil, err
 			}
 
-			groupTrait, err := sdkResource.GetGroupTrait(resource)
-			if err != nil {
-				return nil, nil, fmt.Errorf("okta-connectorv2: failed to get group trait: %w", err)
-			}
-			usersCount, ok := sdkResource.GetProfileInt64Value(groupTrait.Profile, usersCountProfileKey)
+			usersCount, ok := sdkResource.GetProfileInt64Value(resource.GetProfile(), usersCountProfileKey)
 			shouldExpand := !ok || usersCount > 0
 			if !shouldExpand {
 				l.Debug("okta-connectorv2: skipping expand for role group grant since users_count is 0")
@@ -335,29 +327,27 @@ func (o *groupResourceType) listGroupUsers(ctx context.Context, groupID string, 
 }
 
 func (o *groupResourceType) groupResource(ctx context.Context, group *okta.Group) (*v2.Resource, error) {
-	trait, err := o.groupTrait(ctx, group)
-	if err != nil {
-		return nil, err
+	traitOpts := []sdkResource.GroupTraitOption{
+		sdkResource.WithGroupSourceType(sdkResource.GroupSourceType(mapOktaGroupSourceType(group.Type))),
+		sdkResource.WithRawGroupSourceType(group.Type),
 	}
 
-	var annos annotations.Annotations
-	annos.Update(trait)
-	annos.Update(&v2.V1Identifier{
-		Id: fmtResourceIdV1(group.Id),
-	})
-	annos.Update(&v2.RawId{Id: group.Id})
-
+	resourceOpts := []sdkResource.ResourceOption{
+		sdkResource.WithResourceProfile(groupProfileMap(group)),
+		sdkResource.WithAnnotation(&v2.V1Identifier{Id: fmtResourceIdV1(group.Id)}),
+		sdkResource.WithAnnotation(&v2.RawId{Id: group.Id}),
+	}
 	if group.Type == builtInGroupType {
-		annos.Update(&v2.EntitlementImmutable{})
+		resourceOpts = append(resourceOpts, sdkResource.WithAnnotation(&v2.EntitlementImmutable{}))
 	}
-	return &v2.Resource{
-		Id:          fmtResourceId(resourceTypeGroup.Id, group.Id),
-		DisplayName: group.Profile.Name,
-		Annotations: annos,
-	}, nil
+
+	return sdkResource.NewGroupResource(group.Profile.Name, resourceTypeGroup, group.Id, traitOpts, resourceOpts...)
 }
 
-func (o *groupResourceType) groupTrait(ctx context.Context, group *okta.Group) (*v2.GroupTrait, error) {
+// groupProfileMap builds the C1 profile for an Okta group. The profile is set
+// at the resource level (see groupResource). The users_count / apps_count
+// entries drive grant-expansion decisions in Entitlements and Grants.
+func groupProfileMap(group *okta.Group) map[string]interface{} {
 	profileMap := map[string]interface{}{
 		profileFieldDescription: group.Profile.Description,
 		profileFieldName:        group.Profile.Name,
@@ -372,18 +362,7 @@ func (o *groupResourceType) groupTrait(ctx context.Context, group *okta.Group) (
 		profileMap["apps_count"] = int64(appCount)
 	}
 
-	profile, err := structpb.NewStruct(profileMap)
-	if err != nil {
-		return nil, fmt.Errorf("okta-connectorv2: failed to construct group profile for group trait: %w", err)
-	}
-
-	ret := &v2.GroupTrait{
-		Profile:            profile,
-		GroupSourceType:    mapOktaGroupSourceType(group.Type),
-		RawGroupSourceType: group.Type,
-	}
-
-	return ret, nil
+	return profileMap
 }
 
 // mapOktaGroupSourceType maps Okta's group.Type to the C1-normalized source
@@ -540,11 +519,7 @@ func (o *groupResourceType) Get(ctx context.Context, resourceId *v2.ResourceId, 
 		return nil, annos, err
 	}
 
-	groupTrait, err := sdkResource.GetGroupTrait(resource)
-	if err != nil {
-		return nil, annos, fmt.Errorf("okta-connectorv2: failed to get group trait: %w", err)
-	}
-	usersCount, ok := sdkResource.GetProfileInt64Value(groupTrait.Profile, usersCountProfileKey)
+	usersCount, ok := sdkResource.GetProfileInt64Value(resource.GetProfile(), usersCountProfileKey)
 	if ok && usersCount == 0 {
 		groupAnnos := annotations.Annotations(resource.GetAnnotations())
 		groupAnnos.Update(&v2.SkipGrants{})

--- a/pkg/connector/group_test.go
+++ b/pkg/connector/group_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	sdkResource "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
-func TestGroupTrait_TypeProfileKey(t *testing.T) {
+func TestGroupResource_TypeProfileKey(t *testing.T) {
 	tests := []struct {
 		name           string
 		oktaType       string
@@ -35,28 +36,34 @@ func TestGroupTrait_TypeProfileKey(t *testing.T) {
 				},
 			}
 
-			trait, err := o.groupTrait(ctx, group)
+			resource, err := o.groupResource(ctx, group)
 			if err != nil {
-				t.Fatalf("groupTrait returned error: %v", err)
-			}
-			if trait == nil || trait.Profile == nil {
-				t.Fatalf("groupTrait returned nil trait or profile")
+				t.Fatalf("groupResource returned error: %v", err)
 			}
 
-			got, ok := trait.Profile.Fields[groupTypeProfileKey]
-			if !ok {
-				t.Fatalf("profile is missing %q key; fields=%v", groupTypeProfileKey, trait.Profile.Fields)
+			profile := resource.GetProfile()
+			if profile == nil {
+				t.Fatalf("groupResource returned resource with nil profile")
 			}
-			if got.GetStringValue() != tc.want {
-				t.Errorf("profile[%q] = %q, want %q", groupTypeProfileKey, got.GetStringValue(), tc.want)
+
+			got, ok := sdkResource.GetProfileStringValue(profile, groupTypeProfileKey)
+			if !ok {
+				t.Fatalf("profile is missing %q key; fields=%v", groupTypeProfileKey, profile.GetFields())
+			}
+			if got != tc.want {
+				t.Errorf("profile[%q] = %q, want %q", groupTypeProfileKey, got, tc.want)
 			}
 
 			for _, key := range []string{profileFieldName, profileFieldDescription} {
-				if _, ok := trait.Profile.Fields[key]; !ok {
+				if _, ok := profile.GetFields()[key]; !ok {
 					t.Errorf("profile is missing pre-existing %q key", key)
 				}
 			}
 
+			trait, err := sdkResource.GetGroupTrait(resource)
+			if err != nil {
+				t.Fatalf("GetGroupTrait returned error: %v", err)
+			}
 			if got := trait.GetRawGroupSourceType(); got != tc.oktaType {
 				t.Errorf("RawGroupSourceType = %q, want %q", got, tc.oktaType)
 			}

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/url"
 
-	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
@@ -44,13 +43,6 @@ func fmtGrantIdV1(entitlementID string, userID string) string {
 
 func fmtResourceIdV1(id string) string {
 	return id
-}
-
-func fmtResourceId(resourceTypeID string, id string) *v2.ResourceId {
-	return &v2.ResourceId{
-		ResourceType: resourceTypeID,
-		Resource:     id,
-	}
 }
 
 // extractFieldAsString extracts and validates a string field from the arguments struct by key.

--- a/pkg/connector/resource_sets.go
+++ b/pkg/connector/resource_sets.go
@@ -52,9 +52,8 @@ func resourceSetsResource(ctx context.Context, rs *ResourceSets, parentResourceI
 		resourceTypeResourceSets,
 		rs.ID,
 		sdkResource.WithParentResourceID(parentResourceID),
-		sdkResource.WithAppTrait(
-			sdkResource.WithAppProfile(profile),
-		),
+		sdkResource.WithAppTrait(),
+		sdkResource.WithResourceProfile(profile),
 	)
 }
 
@@ -70,9 +69,8 @@ func resourceSetResource(ctx context.Context, rs *oktav5.ResourceSet, parentReso
 		resourceTypeResourceSets,
 		*rs.Id,
 		sdkResource.WithParentResourceID(parentResourceID),
-		sdkResource.WithAppTrait(
-			sdkResource.WithAppProfile(profile),
-		),
+		sdkResource.WithAppTrait(),
+		sdkResource.WithResourceProfile(profile),
 	)
 }
 

--- a/pkg/connector/resource_sets_bindings.go
+++ b/pkg/connector/resource_sets_bindings.go
@@ -51,7 +51,8 @@ func resourceSetsBindingsResource(ctx context.Context, rs *ResourceSets, parentR
 		resourceTypeResourceSetsBindings,
 		rs.ID,
 		sdkResource.WithParentResourceID(parentResourceID),
-		sdkResource.WithAppTrait(sdkResource.WithAppProfile(profile)),
+		sdkResource.WithAppTrait(),
+		sdkResource.WithResourceProfile(profile),
 	)
 }
 
@@ -67,7 +68,8 @@ func resourceSetBindingsResource(ctx context.Context, rs *oktav5.ResourceSet, pa
 		resourceTypeResourceSetsBindings,
 		rs.GetId(),
 		sdkResource.WithParentResourceID(parentResourceID),
-		sdkResource.WithAppTrait(sdkResource.WithAppProfile(profile)),
+		sdkResource.WithAppTrait(),
+		sdkResource.WithResourceProfile(profile),
 	)
 }
 func (rsb *resourceSetsBindingsResourceType) List(ctx context.Context, parentResourceID *v2.ResourceId, attrs sdkResource.SyncOpAttrs) ([]*v2.Resource, *sdkResource.SyncOpResults, error) {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -390,7 +390,8 @@ func roleResource(ctx context.Context, role *okta.Role, ctype *v2.ResourceType) 
 		role.Label,
 		ctype,
 		objectID,
-		[]sdkResource.RoleTraitOption{sdkResource.WithRoleProfile(profile)},
+		[]sdkResource.RoleTraitOption{},
+		sdkResource.WithResourceProfile(profile),
 		sdkResource.WithAnnotation(&v2.V1Identifier{
 			Id: V1RoleEntitlementID(objectID),
 		}),

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -270,10 +270,13 @@ func userResource(ctx context.Context, user *okta.User, skipSecondaryEmails bool
 	oktaProfile["c1_okta_raw_user_status"] = user.Status
 
 	options := []resource.UserTraitOption{
-		resource.WithUserProfile(oktaProfile),
 		// TODO?: use the user types API to figure out the account type
 		// https://developer.okta.com/docs/reference/api/user-types/
 		// resource.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_UNSPECIFIED),
+	}
+
+	resourceOpts := []resource.ResourceOption{
+		resource.WithResourceProfile(oktaProfile),
 	}
 
 	displayName, ok := oktaProfile["displayName"].(string)
@@ -282,7 +285,7 @@ func userResource(ctx context.Context, user *okta.User, skipSecondaryEmails bool
 	}
 
 	if user.Created != nil {
-		options = append(options, resource.WithCreatedAt(*user.Created))
+		resourceOpts = append(resourceOpts, resource.WithResourceCreatedAt(*user.Created))
 	}
 	if user.LastLogin != nil {
 		options = append(options, resource.WithLastLogin(*user.LastLogin))
@@ -328,20 +331,24 @@ func userResource(ctx context.Context, user *okta.User, skipSecondaryEmails bool
 	// case userStatusDeprovisioned:
 	// options = append(options, resource.WithDetailedStatus(v2.UserTrait_Status_STATUS_DELETED, user.Status))
 	case userStatusSuspended, userStatusDeprovisioned:
-		options = append(options, resource.WithDetailedStatus(v2.UserTrait_Status_STATUS_DISABLED, user.Status))
+		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_DISABLED, user.Status))
 	case userStatusActive, userStatusProvisioned, userStatusStaged, userStatusPasswordExpired, userStatusRecovery, userStatusLockedOut:
-		options = append(options, resource.WithDetailedStatus(v2.UserTrait_Status_STATUS_ENABLED, user.Status))
+		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, user.Status))
 	default:
-		options = append(options, resource.WithDetailedStatus(v2.UserTrait_Status_STATUS_UNSPECIFIED, user.Status))
+		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_UNSPECIFIED, user.Status))
 	}
+
+	resourceOpts = append(resourceOpts,
+		resource.WithAnnotation(&v2.V1Identifier{Id: fmtResourceIdV1(user.Id)}),
+		resource.WithAnnotation(&v2.RawId{Id: user.Id}),
+	)
 
 	ret, err := resource.NewUserResource(
 		displayName,
 		resourceTypeUser,
 		user.Id,
 		options,
-		resource.WithAnnotation(&v2.V1Identifier{Id: fmtResourceIdV1(user.Id)}),
-		resource.WithAnnotation(&v2.RawId{Id: user.Id}),
+		resourceOpts...,
 	)
 	return ret, err
 }


### PR DESCRIPTION
## What

Clears all `golangci-lint` **staticcheck SA1019** warnings on `main`. The baton-sdk moved `profile`, `created_at`, and `status` off the individual traits and onto the `Resource` itself, deprecating the trait-level options.

## Changes

- **user / app / role / secret / resource-sets**: moved `WithUserProfile` / `WithAppProfile` / `WithRoleProfile` / `WithSecretCreatedAt` / `WithCreatedAt` / `WithDetailedStatus` out of the trait option lists and replaced them with the resource-level options `WithResourceProfile`, `WithResourceCreatedAt`, and `WithResourceStatus`.
- **groups**: `groupResource` now builds via `sdkResource.NewGroupResource` using the non-deprecated `WithGroupSourceType` / `WithRawGroupSourceType` trait options, with the profile set at the resource level (`WithResourceProfile`). The internal `users_count` reads in `Entitlements`/`Grants` now read `resource.GetProfile()` instead of the deprecated `GroupTrait.Profile`.
- Removed the now-unused `fmtResourceId` helper.
- Renamed `TestGroupTrait_TypeProfileKey` → `TestGroupResource_TypeProfileKey`; it now asserts against the resource-level profile via non-deprecated accessors.

No `//nolint` suppressions were introduced.

## Notes

The resource-status enum values map 1:1 (`STATUS_DISABLED`→`RESOURCE_STATUS_DISABLED`, etc.). Group `GroupSourceType`/`RawGroupSourceType` values are preserved exactly, and `NewResourceID` produces the same resource ID as the old `fmtResourceId`.

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (all passing)
- `golangci-lint run ./...` ✅ 0 issues (was 19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)