### PR TITLE
feat: support provider_type and send_activation_email for account creation

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -260,6 +260,26 @@ func (c *Okta) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 					Placeholder: "True/False",
 					Order:       6,
 				},
+				profileFieldSendActivationEmail: {
+					DisplayName: "Send Activation Email",
+					Required:    false,
+					Description: "When set to 'false', the Okta activation email is suppressed by creating the user staged and activating without sending an email. Defaults to 'true'.",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "True/False",
+					Order:       7,
+				},
+				profileFieldProviderType: {
+					DisplayName: "Provider Type",
+					Required:    false,
+					Description: "The authentication provider type for the user. Set to 'FEDERATION' to create a federated user (no Okta password). Defaults to 'OKTA'.",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "OKTA/FEDERATION",
+					Order:       8,
+				},
 				profileFieldAdditionalAttributes: {
 					DisplayName: "Additional Attributes",
 					Required:    false,
@@ -267,7 +287,7 @@ func (c *Okta) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 					Field: &v2.ConnectorAccountCreationSchema_Field_MapField{
 						MapField: &v2.ConnectorAccountCreationSchema_MapField{},
 					},
-					Order: 7,
+					Order: 9,
 				},
 			},
 		},

--- a/pkg/connector/profile_keys.go
+++ b/pkg/connector/profile_keys.go
@@ -15,9 +15,16 @@ const (
 const userResourceTypeID = "user"
 
 const (
-	profileFieldCreateInactive               = "create_inactive"
-	profileFieldAdditionalAttributes         = "additionalAttributes"
+	profileFieldCreateInactive                = "create_inactive"
+	profileFieldAdditionalAttributes          = "additionalAttributes"
 	profileFieldPasswordChangeOnLoginRequired = "password_change_on_login_required"
+	profileFieldSendActivationEmail           = "send_activation_email"
+	profileFieldProviderType                  = "provider_type"
+)
+
+const (
+	providerTypeOkta       = "OKTA"
+	providerTypeFederation = "FEDERATION"
 )
 
 // protectedOktaProfileFields lists the core profile keys set explicitly during

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -395,7 +395,25 @@ func (r *userResourceType) CreateAccount(
 		return nil, nil, nil, err
 	}
 
-	params, err := getAccountCreationQueryParams(accountInfo, credentialOptions)
+	providerType, err := getProviderType(accountInfo)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if providerType == providerTypeFederation {
+		// Federated users are mastered by an external IdP and cannot have an Okta password.
+		if credentialOptions.GetRandomPassword() != nil {
+			return nil, nil, nil, fmt.Errorf("okta-connectorv2: %s=%s cannot be combined with a random password credential option", profileFieldProviderType, providerTypeFederation)
+		}
+		if creds == nil {
+			creds = &okta.UserCredentials{}
+		}
+		creds.Provider = &okta.AuthenticationProvider{
+			Type: providerTypeFederation,
+			Name: providerTypeFederation,
+		}
+	}
+
+	params, suppressActivationEmail, err := getAccountCreationQueryParams(accountInfo, credentialOptions, providerType)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -413,6 +431,16 @@ func (r *userResourceType) CreateAccount(
 	}
 	if response != nil && response.StatusCode != http.StatusOK {
 		return nil, nil, nil, fmt.Errorf("okta-connectorv2: failed to create user: %s", response.Status)
+	}
+
+	if suppressActivationEmail {
+		_, activateResp, err := r.connector.client.User.ActivateUser(ctx, user.Id, query.NewQueryParams(query.WithSendEmail(false)))
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("okta-connectorv2: user created but activation failed: %w", err)
+		}
+		if activateResp != nil && activateResp.StatusCode != http.StatusOK {
+			return nil, nil, nil, fmt.Errorf("okta-connectorv2: user created but activation returned non-200: %s", activateResp.Status)
+		}
 	}
 
 	userResource, err := userResource(ctx, user, r.connector.skipSecondaryEmails)
@@ -491,9 +519,20 @@ func getUserProfile(accountInfo *v2.AccountInfo) (*okta.UserProfile, error) {
 	return profile, nil
 }
 
-func getAccountCreationQueryParams(accountInfo *v2.AccountInfo, credentialOptions *v2.LocalCredentialOptions) (*query.Params, error) {
+// getAccountCreationQueryParams builds the Create User query params from the account
+// profile. When providerType is FEDERATION it sets provider=true so Okta honors the
+// credentials.provider block. It also returns whether the caller must perform a follow-up
+// activation with sendEmail=false (used to suppress the activation email, since the Create
+// User endpoint itself does not honor sendEmail).
+func getAccountCreationQueryParams(accountInfo *v2.AccountInfo, credentialOptions *v2.LocalCredentialOptions, providerType string) (*query.Params, bool, error) {
 	pMap := accountInfo.Profile.AsMap()
 	params := &query.Params{}
+
+	// Okta only honors credentials.provider when the provider=true query param is set;
+	// without it the provider block is ignored and a default OKTA user is created.
+	if providerType == providerTypeFederation {
+		params.Provider = true
+	}
 
 	// create_inactive applies regardless of credential type
 	createInactive := false
@@ -503,40 +542,91 @@ func getAccountCreationQueryParams(accountInfo *v2.AccountInfo, credentialOption
 	case string:
 		parsed, err := strconv.ParseBool(v)
 		if err != nil {
-			return nil, fmt.Errorf("okta-connectorv2: invalid value for %s: %w", profileFieldCreateInactive, err)
+			return nil, false, fmt.Errorf("okta-connectorv2: invalid value for %s: %w", profileFieldCreateInactive, err)
 		}
 		createInactive = parsed
 	case nil:
 		// absent = default false, activate=true is Okta's default
 	}
 
+	// send_activation_email defaults to true to preserve existing behavior
+	sendActivationEmail := true
+	switch v := pMap[profileFieldSendActivationEmail].(type) {
+	case bool:
+		sendActivationEmail = v
+	case string:
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, false, fmt.Errorf("okta-connectorv2: invalid value for %s: %w", profileFieldSendActivationEmail, err)
+		}
+		sendActivationEmail = parsed
+	case nil:
+		// absent = default true
+	}
+
 	if createInactive {
 		params.Activate = ToPtr(false)
-		return params, nil
+		return params, false, nil
 	}
 
 	// random-password path: respect password_change_on_login_required
+	requirePasswordChanged := false
 	if credentialOptions.GetRandomPassword() != nil {
-		requirePasswordChanged := false
 		switch v := pMap[profileFieldPasswordChangeOnLoginRequired].(type) {
 		case bool:
 			requirePasswordChanged = v
 		case string:
 			parsed, err := strconv.ParseBool(v)
 			if err != nil {
-				return nil, fmt.Errorf("okta-connectorv2: invalid value for %s: %w", profileFieldPasswordChangeOnLoginRequired, err)
+				return nil, false, fmt.Errorf("okta-connectorv2: invalid value for %s: %w", profileFieldPasswordChangeOnLoginRequired, err)
 			}
 			requirePasswordChanged = parsed
 		case nil:
 			// absent = default false
 		}
-		if requirePasswordChanged {
-			params.NextLogin = "changePassword"
-			params.Activate = ToPtr(true)
-		}
 	}
 
-	return params, nil
+	// Suppressing the activation email uses the staged-create + activate(sendEmail=false)
+	// flow, which cannot also honor nextLogin=changePassword.
+	if !sendActivationEmail && requirePasswordChanged {
+		return nil, false, fmt.Errorf("okta-connectorv2: %s=false cannot be combined with %s=true", profileFieldSendActivationEmail, profileFieldPasswordChangeOnLoginRequired)
+	}
+
+	if !sendActivationEmail {
+		// Stage the user so no activation email is sent; the caller activates with sendEmail=false.
+		params.Activate = ToPtr(false)
+		return params, true, nil
+	}
+
+	if requirePasswordChanged {
+		params.NextLogin = "changePassword"
+		params.Activate = ToPtr(true)
+	}
+
+	return params, false, nil
+}
+
+// getProviderType reads the optional provider_type profile field. It returns an empty
+// string when unset (equivalent to the default Okta provider), the normalized value for
+// OKTA or FEDERATION, and an error for any unsupported value.
+func getProviderType(accountInfo *v2.AccountInfo) (string, error) {
+	raw, ok := accountInfo.Profile.AsMap()[profileFieldProviderType]
+	if !ok || raw == nil {
+		return "", nil
+	}
+
+	providerType, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("okta-connectorv2: %s must be a string", profileFieldProviderType)
+	}
+
+	providerType = strings.ToUpper(strings.TrimSpace(providerType))
+	switch providerType {
+	case "", providerTypeOkta, providerTypeFederation:
+		return providerType, nil
+	default:
+		return "", fmt.Errorf("okta-connectorv2: unsupported %s value %q (supported: %q, %q)", profileFieldProviderType, providerType, providerTypeOkta, providerTypeFederation)
+	}
 }
 
 func (o *userResourceType) Get(ctx context.Context, resourceId *v2.ResourceId, parentResourceId *v2.ResourceId) (*v2.Resource, annotations.Annotations, error) {

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -330,12 +330,15 @@ func TestGetAccountCreationQueryParams(t *testing.T) {
 	}.Build()
 
 	tests := []struct {
-		name        string
-		profile     map[string]interface{}
-		creds       *v2.LocalCredentialOptions
-		wantActivate *bool   // nil means we don't care / field should be unset
-		wantNextLogin string  // empty means field should be unset
-		wantErr     bool
+		name          string
+		profile       map[string]interface{}
+		creds         *v2.LocalCredentialOptions
+		providerType  string
+		wantActivate  *bool  // nil means we don't care / field should be unset
+		wantNextLogin string // empty means field should be unset
+		wantProvider  bool
+		wantSuppress  bool
+		wantErr       bool
 	}{
 		{
 			name:    "all defaults no-password",
@@ -364,8 +367,8 @@ func TestGetAccountCreationQueryParams(t *testing.T) {
 				"create_inactive":                   true,
 				"password_change_on_login_required": true,
 			},
-			creds:        randomPassword,
-			wantActivate: boolPtr(false),
+			creds:         randomPassword,
+			wantActivate:  boolPtr(false),
 			wantNextLogin: "",
 		},
 		{
@@ -397,6 +400,90 @@ func TestGetAccountCreationQueryParams(t *testing.T) {
 			profile: map[string]interface{}{},
 			creds:   randomPassword,
 		},
+		{
+			name: "send_activation_email absent keeps default behavior",
+			profile: map[string]interface{}{
+				"send_activation_email": nil,
+			},
+			creds: noPassword,
+		},
+		{
+			name: "send_activation_email true explicit keeps default behavior",
+			profile: map[string]interface{}{
+				"send_activation_email": true,
+			},
+			creds: noPassword,
+		},
+		{
+			name: "send_activation_email false bool stages and suppresses",
+			profile: map[string]interface{}{
+				"send_activation_email": false,
+			},
+			creds:        noPassword,
+			wantActivate: boolPtr(false),
+			wantSuppress: true,
+		},
+		{
+			name: "send_activation_email false string stages and suppresses",
+			profile: map[string]interface{}{
+				"send_activation_email": "false",
+			},
+			creds:        noPassword,
+			wantActivate: boolPtr(false),
+			wantSuppress: true,
+		},
+		{
+			name: "create_inactive wins over send_activation_email false",
+			profile: map[string]interface{}{
+				"create_inactive":       true,
+				"send_activation_email": false,
+			},
+			creds:        noPassword,
+			wantActivate: boolPtr(false),
+			wantSuppress: false,
+		},
+		{
+			name: "send_activation_email invalid string",
+			profile: map[string]interface{}{
+				"send_activation_email": "nope",
+			},
+			creds:   noPassword,
+			wantErr: true,
+		},
+		{
+			name: "send_activation_email false conflicts with password_change",
+			profile: map[string]interface{}{
+				"send_activation_email":             false,
+				"password_change_on_login_required": true,
+			},
+			creds:   randomPassword,
+			wantErr: true,
+		},
+		{
+			name:         "federation provider sets provider query param",
+			profile:      map[string]interface{}{},
+			creds:        noPassword,
+			providerType: providerTypeFederation,
+			wantProvider: true,
+		},
+		{
+			name:         "okta provider does not set provider query param",
+			profile:      map[string]interface{}{},
+			creds:        noPassword,
+			providerType: providerTypeOkta,
+			wantProvider: false,
+		},
+		{
+			name: "federation provider with send_activation_email false stages and sets provider",
+			profile: map[string]interface{}{
+				"send_activation_email": false,
+			},
+			creds:        noPassword,
+			providerType: providerTypeFederation,
+			wantActivate: boolPtr(false),
+			wantProvider: true,
+			wantSuppress: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -407,7 +494,7 @@ func TestGetAccountCreationQueryParams(t *testing.T) {
 			}
 			accountInfo := &v2.AccountInfo{Profile: s}
 
-			got, err := getAccountCreationQueryParams(accountInfo, tt.creds)
+			got, suppress, err := getAccountCreationQueryParams(accountInfo, tt.creds, tt.providerType)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -435,6 +522,95 @@ func TestGetAccountCreationQueryParams(t *testing.T) {
 			// Check NextLogin
 			if got != nil && got.NextLogin != tt.wantNextLogin {
 				t.Errorf("NextLogin = %q, want %q", got.NextLogin, tt.wantNextLogin)
+			}
+
+			// Check Provider query param
+			gotProvider := false
+			if got != nil {
+				if b, ok := got.Provider.(bool); ok {
+					gotProvider = b
+				}
+			}
+			if gotProvider != tt.wantProvider {
+				t.Errorf("Provider = %v, want %v", gotProvider, tt.wantProvider)
+			}
+
+			if suppress != tt.wantSuppress {
+				t.Errorf("suppress = %v, want %v", suppress, tt.wantSuppress)
+			}
+		})
+	}
+}
+
+func TestGetProviderType(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "absent defaults to empty",
+			profile: map[string]interface{}{},
+			want:    "",
+		},
+		{
+			name: "explicit nil defaults to empty",
+			profile: map[string]interface{}{
+				"provider_type": nil,
+			},
+			want: "",
+		},
+		{
+			name: "okta uppercase",
+			profile: map[string]interface{}{
+				"provider_type": "OKTA",
+			},
+			want: providerTypeOkta,
+		},
+		{
+			name: "federation lowercase normalized",
+			profile: map[string]interface{}{
+				"provider_type": "federation",
+			},
+			want: providerTypeFederation,
+		},
+		{
+			name: "federation with surrounding whitespace",
+			profile: map[string]interface{}{
+				"provider_type": "  FEDERATION  ",
+			},
+			want: providerTypeFederation,
+		},
+		{
+			name: "unsupported value rejected",
+			profile: map[string]interface{}{
+				"provider_type": "SOCIAL",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := structpb.NewStruct(tt.profile)
+			if err != nil {
+				t.Fatalf("structpb.NewStruct: %v", err)
+			}
+			accountInfo := &v2.AccountInfo{Profile: s}
+
+			got, err := getProviderType(accountInfo)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("getProviderType() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR covers two gaps in account creation functionality. 

#1: Currently, account creation does not allow you to create a FEDERATION okta provider type. This is a common scenario in okta hub/spoke org designs where user's login to a downstream Okta tenant via federation. We default to a provider_type of "" to ensure backwards compatability/no breaking changes for current users but also accept "OKTA" and now "FEDERATION".

#2. When creating an Okta user, there are workflow use cases where a customer may not want to send the Okta activation email. We add the ability to provide an optional send_activation_email of "True" or "False". This still activates the user but does not send the Okta-related activation email to the end-user.  This also defaults back to True to ensure that this is handled in an opt-in fashion and doesn't impact existing workflows for customers.