### PR TITLE
[CXH-2201, CXH-2199] - Leave adopted staged users inactive and reject wrong-typed additionalAttributes - Okta Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Precedence notes:
 
 - `create_inactive=true` wins over `send_activation_email` — the user stays staged; no activation follow-up runs.
 - `password_change_on_login_required` is inert on the no-password credential path (same as before this feature).
+- A key present with the wrong type fails the request instead of being ignored, so a mapping mistake surfaces rather than creating an account that is missing what was asked for. Only an absent or null key falls back to its default.
 
 Example (federated user, no activation email):
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -62,6 +62,10 @@ When you configure account provisioning for Okta, C1 shows the following optiona
 **Provider Type** `FEDERATION` cannot be combined with a random-password credential option (federated users have no Okta password). **Send Activation Email** `False` cannot be combined with **Password Change Required on Login** `True` when creating with a random password (that combination cannot set Okta's change-password-on-login flag). With a no-password credential option, Password Change Required on Login has no effect and does not conflict. If **Create Inactive** is `True`, the connector leaves the user staged and does not run the activation step — Create Inactive takes precedence over Send Activation Email.
 </Note>
 
+<Note>
+If you map one of these fields to an expression, make sure the expression returns the field's type: **Additional Attributes** must return a map, and the `True` / `False` fields must return a boolean. Account creation fails with an error when a mapped value has the wrong type, so the account is never created without the values you asked for. Leaving a field unmapped uses its default.
+</Note>
+
 Syncing standard and custom admin roles requires a super admin token. 
 
 [This connector can sync secrets](/product/admin/inventory) and display them on the **Inventory** page. 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -101,17 +101,16 @@ Doc root: [Okta Users API](https://developer.okta.com/docs/reference/api/users/)
 
 The suppressed-email flow spans three calls, so a failure can leave the user created but not
 activated. On retry, Okta rejects the create with `E0000001` and an `errorCauses` entry naming
-`login`. The connector adopts that user **only when** `send_activation_email=false` was requested
-**and** the existing user is still `STAGED`, and returns `AlreadyExistsResult`. A duplicate login
-against an already-ACTIVE (or otherwise non-STAGED) account is returned as the original create
-error — it is a genuine collision, not a retry.
+`login`. Any duplicate login returns `AlreadyExistsResult` carrying the existing Okta user,
+whatever its status, so the caller converges on that account instead of failing forever.
 
-An **adopted** user's lifecycle is never changed: only a user staged by the same call is activated.
-`STAGED` does not identify a stranded attempt — `create_inactive=true` and an admin-staged user look
-identical — so activating on adoption would override an explicit "keep this account inactive"
-decision. The trade-off is that a retry after a failed activation reports `AlreadyExistsResult` with
-the user still `STAGED`; finishing activation is then an explicit operation (`enable_user`, or
-activation in Okta), not a side effect of a repeated create.
+The existing user's lifecycle is never changed — activation runs only for a user this same call
+created. `STAGED` does not identify a stranded attempt: `create_inactive=true` and an admin-staged
+account look identical, so activating on a duplicate would override an explicit "keep this account
+inactive" decision. The trade-off is that a retry after a failed activation reports
+`AlreadyExistsResult` with the user still `STAGED`, and finishing activation has to happen in Okta.
+The `enable_user` action does not cover this case: it unsuspends a `SUSPENDED` user and rejects any
+other status, `STAGED` included.
 
 ### Org2Org / hub-spoke
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -72,7 +72,7 @@ Account creation is driven by `AccountCreationSchema` in `pkg/connector/connecto
 | `create_inactive` | no | false | `activate=false`; skips activation follow-up |
 | `send_activation_email` | no | true | Schema `BoolField` (accepts a bool or its string form). When `false`: create staged, then `ActivateUser` with `sendEmail=false`, then re-fetch user |
 | `provider_type` | no | empty (Okta default local provider) | `OKTA` or `FEDERATION` (case-insensitive). `FEDERATION` sets `credentials.provider` + query `provider=true` |
-| `additionalAttributes` | no | — | Map merged into Okta profile; cannot override protected keys |
+| `additionalAttributes` | no | — | Map merged into Okta profile; cannot override protected keys. A value of any other type is rejected, not dropped |
 
 ### Wire format / Okta calls
 
@@ -82,7 +82,7 @@ Doc root: [Okta Users API](https://developer.okta.com/docs/reference/api/users/)
 | :--- | :--- | :--- |
 | Create user | `POST /api/v1/users` | Query: `activate`, `provider`, optional `nextLogin` |
 | Activate user | `POST /api/v1/users/{id}/lifecycle/activate` | Query: `sendEmail=false` when suppressing activation email |
-| Get user | `GET /api/v1/users/{idOrLogin}` | Re-fetch after activate to pick up the post-activation status; best-effort, a failure keeps the created user. Also used to adopt an existing login on retry |
+| Get user | `GET /api/v1/users/{idOrLogin}` | Re-fetch after activate to pick up the post-activation status; best-effort, a failure keeps the created user. Also used to resolve an existing login on retry |
 
 ### Conflict / validation rules
 
@@ -90,15 +90,28 @@ Doc root: [Okta Users API](https://developer.okta.com/docs/reference/api/users/)
 - `send_activation_email=false` + `password_change_on_login_required=true` + **random password** → error (staged+activate path cannot also set `nextLogin=changePassword`). On the no-password path, `password_change_on_login_required` is inert and does not conflict (pre-existing behavior).
 - `create_inactive=true` wins over `send_activation_email` / `password_change_on_login_required`: evaluated first, user stays staged, no activate call, and the conflict check above is skipped.
 - Without query `provider=true`, Okta **ignores** a `credentials.provider` block and creates a normal OKTA user (verified live).
+- A profile field present with the wrong type is always an error, never a silent fallback: booleans
+  (`create_inactive`, `send_activation_email`, `password_change_on_login_required`) must be a bool or
+  its string form, and `additionalAttributes` must be an object. Only an absent or null key falls back
+  to the default, because creating the account without what the caller asked for would report success
+  for a different outcome. The C1 mapping screen does not validate the mapped expression's type, so a
+  CEL expression returning the wrong type is caught here.
 
 ### Retry semantics
 
 The suppressed-email flow spans three calls, so a failure can leave the user created but not
 activated. On retry, Okta rejects the create with `E0000001` and an `errorCauses` entry naming
 `login`. The connector adopts that user **only when** `send_activation_email=false` was requested
-**and** the existing user is still `STAGED` (the stranded partial-create case), then activates and
-returns `AlreadyExistsResult`. A duplicate login against an already-ACTIVE (or otherwise non-STAGED)
-account is returned as the original create error — it is a genuine collision, not a retry.
+**and** the existing user is still `STAGED`, and returns `AlreadyExistsResult`. A duplicate login
+against an already-ACTIVE (or otherwise non-STAGED) account is returned as the original create
+error — it is a genuine collision, not a retry.
+
+An **adopted** user's lifecycle is never changed: only a user staged by the same call is activated.
+`STAGED` does not identify a stranded attempt — `create_inactive=true` and an admin-staged user look
+identical — so activating on adoption would override an explicit "keep this account inactive"
+decision. The trade-off is that a retry after a failed activation reports `AlreadyExistsResult` with
+the user still `STAGED`; finishing activation is then an explicit operation (`enable_user`, or
+activation in Okta), not a side effect of a repeated create.
 
 ### Org2Org / hub-spoke
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -109,8 +109,10 @@ created. `STAGED` does not identify a stranded attempt: `create_inactive=true` a
 account look identical, so activating on a duplicate would override an explicit "keep this account
 inactive" decision. The trade-off is that a retry after a failed activation reports
 `AlreadyExistsResult` with the user still `STAGED`, and finishing activation has to happen in Okta.
-The `enable_user` action does not cover this case: it unsuspends a `SUSPENDED` user and rejects any
-other status, `STAGED` included.
+The `enable_user` action does not cover this case: it only unsuspends a `SUSPENDED` user. On any other
+status (including `STAGED`) Okta returns "Cannot unsuspend a user that is not suspended", and the
+action swallows that into a success response (`Account … was already enabled`) without changing the
+user — so the account stays `STAGED`.
 
 ### Org2Org / hub-spoke
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -101,8 +101,10 @@ Doc root: [Okta Users API](https://developer.okta.com/docs/reference/api/users/)
 
 The suppressed-email flow spans three calls, so a failure can leave the user created but not
 activated. On retry, Okta rejects the create with `E0000001` and an `errorCauses` entry naming
-`login`. Any duplicate login returns `AlreadyExistsResult` carrying the existing Okta user,
-whatever its status, so the caller converges on that account instead of failing forever.
+`login`. Any duplicate login returns `AlreadyExistsResult` — with the existing Okta user when
+the follow-up fetch succeeds, or without a Resource when the lookup fails — so the caller
+converges on that account (or the next sync correlates it) instead of failing forever. The
+existing user's status does not matter.
 
 The existing user's lifecycle is never changed — activation runs only for a user this same call
 created. `STAGED` does not identify a stranded attempt: `create_inactive=true` and an admin-staged

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -413,13 +413,10 @@ func (r *userResourceType) CreateAccount(
 		Credentials: creds,
 	}, params)
 
-	// A suppressed-activation attempt can leave the user created but not yet activated.
-	// Adopt a STAGED account so a retry converges instead of failing on the duplicate
-	// login forever; any other duplicate login is a genuine collision and must surface as
-	// an error. STAGED does not prove the account is a stranded attempt of ours —
-	// create_inactive and admin-staged users are indistinguishable — so an adopted user's
-	// lifecycle is left untouched below.
-	alreadyExists := false
+	// The login already belongs to an Okta user, so return that account rather than
+	// failing the duplicate forever. Its lifecycle is left untouched: a STAGED collision
+	// is indistinguishable from an account someone deliberately staged (create_inactive,
+	// or an Okta admin), so activating it here would override that decision.
 	switch {
 	case isDuplicateLoginError(err):
 		login, ok := (*userProfile)[profileFieldLogin].(string)
@@ -430,24 +427,25 @@ func (r *userResourceType) CreateAccount(
 		if getErr != nil {
 			return nil, nil, nil, fmt.Errorf("okta-connectorv2: login %s already exists but fetch failed: %w", login, getErr)
 		}
-		// A collision with a user past STAGED is an account we did not create, so it has to
-		// reach a human as AlreadyExists rather than be silently adopted.
-		if !suppressActivationEmail || existing.Status != userStatusStaged {
-			return nil, nil, nil, uhttp.WrapErrors(codes.AlreadyExists, fmt.Sprintf("okta-connectorv2: login %s already exists on user %s with status %s", login, existing.Id, existing.Status), err)
-		}
-		ctxzap.Extract(ctx).Debug("okta-connectorv2: adopted an existing staged user; leaving its status unchanged",
+		ctxzap.Extract(ctx).Debug("okta-connectorv2: login already exists; returning the existing user unchanged",
 			zap.String("user_id", existing.Id),
 			zap.String("login", login),
+			zap.String("status", existing.Status),
 		)
-		user = existing
-		alreadyExists = true
+		existingResource, err := userResource(existing, r.connector.skipSecondaryEmails)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		return &v2.CreateAccountResponse_AlreadyExistsResult{Resource: existingResource}, nil, nil, nil
 	case err != nil:
 		return nil, nil, nil, err
 	case response != nil && response.StatusCode != http.StatusOK:
 		return nil, nil, nil, fmt.Errorf("okta-connectorv2: failed to create user: %s", response.Status)
 	}
 
-	if shouldActivateAfterCreate(suppressActivationEmail, alreadyExists, user.Status) {
+	// Only a user this call just created reaches this point, and a suppressed create
+	// always staged it, so no status check is needed.
+	if suppressActivationEmail {
 		_, activateResp, err := r.connector.client.User.ActivateUser(ctx, user.Id, query.NewQueryParams(query.WithSendEmail(false)))
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("okta-connectorv2: user %s is staged but activation failed: %w", user.Id, err)
@@ -474,21 +472,7 @@ func (r *userResourceType) CreateAccount(
 		return nil, nil, nil, err
 	}
 
-	if alreadyExists {
-		return &v2.CreateAccountResponse_AlreadyExistsResult{Resource: userResource}, nil, nil, nil
-	}
-
 	return &v2.CreateAccountResponse_SuccessResult{Resource: userResource}, nil, nil, nil
-}
-
-// shouldActivateAfterCreate reports whether the staged user must be activated with the
-// activation email suppressed. Only a user staged by this very call qualifies: an
-// already-existing account (alreadyExists) may have been staged deliberately
-// (create_inactive) or by an Okta admin, and activating it would override an explicit
-// decision to keep it inactive. Activation is also only valid from STAGED, so a user
-// past that point is left alone.
-func shouldActivateAfterCreate(suppressActivationEmail, alreadyExists bool, status string) bool {
-	return suppressActivationEmail && !alreadyExists && status == userStatusStaged
 }
 
 // applyProviderCredentials attaches the federated authentication provider to the

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -482,12 +482,13 @@ func (r *userResourceType) CreateAccount(
 }
 
 // shouldActivateAfterCreate reports whether the staged user must be activated with the
-// activation email suppressed. Only a user staged by this very call qualifies: an adopted
-// account may have been staged deliberately (create_inactive) or by an Okta admin, and
-// activating it would override an explicit decision to keep it inactive. Activation is
-// also only valid from STAGED, so a user past that point is left alone.
-func shouldActivateAfterCreate(suppressActivationEmail, adopted bool, status string) bool {
-	return suppressActivationEmail && !adopted && status == userStatusStaged
+// activation email suppressed. Only a user staged by this very call qualifies: an
+// already-existing account (alreadyExists) may have been staged deliberately
+// (create_inactive) or by an Okta admin, and activating it would override an explicit
+// decision to keep it inactive. Activation is also only valid from STAGED, so a user
+// past that point is left alone.
+func shouldActivateAfterCreate(suppressActivationEmail, alreadyExists bool, status string) bool {
+	return suppressActivationEmail && !alreadyExists && status == userStatusStaged
 }
 
 // applyProviderCredentials attaches the federated authentication provider to the

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -17,13 +17,11 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
-	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
 )
 
 const (
@@ -417,17 +415,32 @@ func (r *userResourceType) CreateAccount(
 	// failing the duplicate forever. Its lifecycle is left untouched: a STAGED collision
 	// is indistinguishable from an account someone deliberately staged (create_inactive,
 	// or an Okta admin), so activating it here would override that decision.
+	// The conflict already proved the account exists — if the follow-up lookup fails or
+	// cannot resolve a Resource, still return AlreadyExistsResult (without Resource) and
+	// let the next sync correlate it.
 	switch {
 	case isDuplicateLoginError(err):
+		l := ctxzap.Extract(ctx)
 		login, ok := (*userProfile)[profileFieldLogin].(string)
 		if !ok || login == "" {
-			return nil, nil, nil, uhttp.WrapErrors(codes.AlreadyExists, "okta-connectorv2: login already exists but is unusable for lookup", err)
+			l.Debug("okta-connectorv2: login already exists but is unusable for lookup")
+			return &v2.CreateAccountResponse_AlreadyExistsResult{}, nil, nil, nil
 		}
 		existing, _, getErr := r.connector.client.User.GetUser(ctx, login)
 		if getErr != nil {
-			return nil, nil, nil, fmt.Errorf("okta-connectorv2: login %s already exists but fetch failed: %w", login, getErr)
+			l.Debug("okta-connectorv2: login already exists but fetch failed",
+				zap.String("login", login),
+				zap.Error(getErr),
+			)
+			return &v2.CreateAccountResponse_AlreadyExistsResult{}, nil, nil, nil
 		}
-		ctxzap.Extract(ctx).Debug("okta-connectorv2: login already exists; returning the existing user unchanged",
+		if existing == nil {
+			l.Debug("okta-connectorv2: login already exists but user was not found",
+				zap.String("login", login),
+			)
+			return &v2.CreateAccountResponse_AlreadyExistsResult{}, nil, nil, nil
+		}
+		l.Debug("okta-connectorv2: login already exists; returning the existing user unchanged",
 			zap.String("user_id", existing.Id),
 			zap.String("login", login),
 			zap.String("status", existing.Status),

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -379,14 +379,6 @@ func (r *userResourceType) CreateAccount(
 	annotations.Annotations,
 	error,
 ) {
-	if raw, exists := accountInfo.Profile.AsMap()[profileFieldAdditionalAttributes]; exists {
-		if _, ok := raw.(map[string]interface{}); !ok {
-			ctxzap.Extract(ctx).Debug("okta-connectorv2: additionalAttributes was present but not a map; ignoring",
-				zap.String("observed_type", fmt.Sprintf("%T", raw)),
-			)
-		}
-	}
-
 	userProfile, err := getUserProfile(accountInfo)
 	if err != nil {
 		return nil, nil, nil, err
@@ -421,9 +413,12 @@ func (r *userResourceType) CreateAccount(
 		Credentials: creds,
 	}, params)
 
-	// An earlier suppressed-activation attempt can leave the user created but not yet
-	// activated. Adopt only that stranded STAGED account so a retry converges; any other
-	// duplicate login is a genuine collision and must surface as an error.
+	// A suppressed-activation attempt can leave the user created but not yet activated.
+	// Adopt a STAGED account so a retry converges instead of failing on the duplicate
+	// login forever; any other duplicate login is a genuine collision and must surface as
+	// an error. STAGED does not prove the account is a stranded attempt of ours —
+	// create_inactive and admin-staged users are indistinguishable — so an adopted user's
+	// lifecycle is left untouched below.
 	alreadyExists := false
 	switch {
 	case isDuplicateLoginError(err):
@@ -435,12 +430,15 @@ func (r *userResourceType) CreateAccount(
 		if getErr != nil {
 			return nil, nil, nil, fmt.Errorf("okta-connectorv2: login %s already exists but fetch failed: %w", login, getErr)
 		}
-		// Only a prior suppressed-activation attempt of ours can leave a STAGED user behind.
-		// Anything else is a genuine collision with an account we did not create, so it has
-		// to reach a human as AlreadyExists rather than be silently adopted.
+		// A collision with a user past STAGED is an account we did not create, so it has to
+		// reach a human as AlreadyExists rather than be silently adopted.
 		if !suppressActivationEmail || existing.Status != userStatusStaged {
 			return nil, nil, nil, uhttp.WrapErrors(codes.AlreadyExists, fmt.Sprintf("okta-connectorv2: login %s already exists on user %s with status %s", login, existing.Id, existing.Status), err)
 		}
+		ctxzap.Extract(ctx).Debug("okta-connectorv2: adopted an existing staged user; leaving its status unchanged",
+			zap.String("user_id", existing.Id),
+			zap.String("login", login),
+		)
 		user = existing
 		alreadyExists = true
 	case err != nil:
@@ -449,9 +447,7 @@ func (r *userResourceType) CreateAccount(
 		return nil, nil, nil, fmt.Errorf("okta-connectorv2: failed to create user: %s", response.Status)
 	}
 
-	// Activation is only valid from STAGED; an adopted user past that point is already
-	// activated and Okta rejects a second attempt.
-	if suppressActivationEmail && user.Status == userStatusStaged {
+	if shouldActivateAfterCreate(suppressActivationEmail, alreadyExists, user.Status) {
 		_, activateResp, err := r.connector.client.User.ActivateUser(ctx, user.Id, query.NewQueryParams(query.WithSendEmail(false)))
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("okta-connectorv2: user %s is staged but activation failed: %w", user.Id, err)
@@ -483,6 +479,15 @@ func (r *userResourceType) CreateAccount(
 	}
 
 	return &v2.CreateAccountResponse_SuccessResult{Resource: userResource}, nil, nil, nil
+}
+
+// shouldActivateAfterCreate reports whether the staged user must be activated with the
+// activation email suppressed. Only a user staged by this very call qualifies: an adopted
+// account may have been staged deliberately (create_inactive) or by an Okta admin, and
+// activating it would override an explicit decision to keep it inactive. Activation is
+// also only valid from STAGED, so a user past that point is left alone.
+func shouldActivateAfterCreate(suppressActivationEmail, adopted bool, status string) bool {
+	return suppressActivationEmail && !adopted && status == userStatusStaged
 }
 
 // applyProviderCredentials attaches the federated authentication provider to the
@@ -565,13 +570,15 @@ func getUserProfile(accountInfo *v2.AccountInfo) (*okta.UserProfile, error) {
 		profileFieldLogin: login,
 	}
 
-	if additional, ok := pMap[profileFieldAdditionalAttributes].(map[string]interface{}); ok {
-		for k, v := range additional {
-			if protectedOktaProfileFields[k] {
-				return nil, fmt.Errorf("okta-connectorv2: additionalAttributes cannot override protected field %q", k)
-			}
-			(*profile)[k] = v
+	additional, err := parseObjectProfileField(pMap, profileFieldAdditionalAttributes)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range additional {
+		if protectedOktaProfileFields[k] {
+			return nil, fmt.Errorf("okta-connectorv2: additionalAttributes cannot override protected field %q", k)
 		}
+		(*profile)[k] = v
 	}
 
 	return profile, nil
@@ -633,6 +640,24 @@ func getAccountCreationQueryParams(accountInfo *v2.AccountInfo, credentialOption
 	}
 
 	return params, false, nil
+}
+
+// parseObjectProfileField reads an account-creation field declared as a map in the
+// creation schema. Only an absent or null key yields no attributes; a key present with
+// any other type is rejected rather than dropped, because creating the account without
+// the attributes the caller asked for reports success for a different outcome.
+func parseObjectProfileField(pMap map[string]any, key string) (map[string]interface{}, error) {
+	raw, present := pMap[key]
+	if !present || raw == nil {
+		return nil, nil
+	}
+
+	obj, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("okta-connectorv2: %s must be an object, got %T", key, raw)
+	}
+
+	return obj, nil
 }
 
 // parseBoolProfileField reads a boolean account-creation field that C1 may send as a

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -697,57 +697,6 @@ func TestParseObjectProfileField(t *testing.T) {
 	}
 }
 
-func TestShouldActivateAfterCreate(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name          string
-		suppress      bool
-		alreadyExists bool
-		status        string
-		wantActivate  bool
-	}{
-		{
-			name:         "user staged by this call is activated",
-			suppress:     true,
-			status:       userStatusStaged,
-			wantActivate: true,
-		},
-		{
-			name:          "already-existing staged user is left untouched",
-			suppress:      true,
-			alreadyExists: true,
-			status:        userStatusStaged,
-		},
-		{
-			name:     "activation not requested",
-			status:   userStatusStaged,
-			suppress: false,
-		},
-		{
-			name:     "already active user is not re-activated",
-			suppress: true,
-			status:   userStatusActive,
-		},
-		{
-			name:          "already-existing active user is left untouched",
-			suppress:      true,
-			alreadyExists: true,
-			status:        userStatusActive,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got := shouldActivateAfterCreate(tt.suppress, tt.alreadyExists, tt.status); got != tt.wantActivate {
-				t.Errorf("shouldActivateAfterCreate(%v, %v, %q) = %v, want %v", tt.suppress, tt.alreadyExists, tt.status, got, tt.wantActivate)
-			}
-		})
-	}
-}
-
 func TestGetProviderType(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -254,13 +254,36 @@ func TestGetUserProfile(t *testing.T) {
 			wantAbsent: []string{"city"},
 		},
 		{
-			name: "additionalAttributes wrong type silently ignored",
+			name: "additionalAttributes wrong type rejected",
 			profile: map[string]interface{}{
 				"first_name":           "Ada",
 				"last_name":            "Lovelace",
 				"email":                "ada@example.com",
 				"login":                "ada@example.com",
 				"additionalAttributes": "not-a-map",
+			},
+			wantErr: true,
+		},
+		{
+			name: "additionalAttributes null is treated as absent",
+			profile: map[string]interface{}{
+				"first_name":           "Ada",
+				"last_name":            "Lovelace",
+				"email":                "ada@example.com",
+				"login":                "ada@example.com",
+				"additionalAttributes": nil,
+			},
+			wantKeys:   []string{"firstName", "lastName", "email", "login"},
+			wantAbsent: []string{"additionalAttributes"},
+		},
+		{
+			name: "additionalAttributes empty object is accepted",
+			profile: map[string]interface{}{
+				"first_name":           "Ada",
+				"last_name":            "Lovelace",
+				"email":                "ada@example.com",
+				"login":                "ada@example.com",
+				"additionalAttributes": map[string]interface{}{},
 			},
 			wantKeys:   []string{"firstName", "lastName", "email", "login"},
 			wantAbsent: []string{"additionalAttributes"},
@@ -618,6 +641,108 @@ func TestParseBoolProfileField(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("parseBoolProfileField() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseObjectProfileField(t *testing.T) {
+	t.Parallel()
+
+	const key = "additionalAttributes"
+
+	tests := []struct {
+		name    string
+		pMap    map[string]any
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{name: "absent yields no attributes", pMap: map[string]any{}},
+		{name: "nil yields no attributes", pMap: map[string]any{key: nil}},
+		{name: "empty object yields no attributes", pMap: map[string]any{key: map[string]interface{}{}}, want: map[string]interface{}{}},
+		{
+			name: "object is returned",
+			pMap: map[string]any{key: map[string]interface{}{"city": "London"}},
+			want: map[string]interface{}{"city": "London"},
+		},
+		{name: "string errors instead of being dropped", pMap: map[string]any{key: "city=London"}, wantErr: true},
+		{name: "number errors", pMap: map[string]any{key: float64(1)}, wantErr: true},
+		{name: "bool errors", pMap: map[string]any{key: true}, wantErr: true},
+		{name: "list errors", pMap: map[string]any{key: []any{"city"}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseObjectProfileField(tt.pMap, key)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseObjectProfileField() = %v, want %v", got, tt.want)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("key %q = %v, want %v", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestShouldActivateAfterCreate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		suppress     bool
+		adopted      bool
+		status       string
+		wantActivate bool
+	}{
+		{
+			name:         "user staged by this call is activated",
+			suppress:     true,
+			status:       userStatusStaged,
+			wantActivate: true,
+		},
+		{
+			name:     "adopted staged user is left untouched",
+			suppress: true,
+			adopted:  true,
+			status:   userStatusStaged,
+		},
+		{
+			name:     "activation not requested",
+			status:   userStatusStaged,
+			suppress: false,
+		},
+		{
+			name:     "already active user is not re-activated",
+			suppress: true,
+			status:   userStatusActive,
+		},
+		{
+			name:     "adopted active user is left untouched",
+			suppress: true,
+			adopted:  true,
+			status:   userStatusActive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := shouldActivateAfterCreate(tt.suppress, tt.adopted, tt.status); got != tt.wantActivate {
+				t.Errorf("shouldActivateAfterCreate(%v, %v, %q) = %v, want %v", tt.suppress, tt.adopted, tt.status, got, tt.wantActivate)
 			}
 		})
 	}

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -701,11 +701,11 @@ func TestShouldActivateAfterCreate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		suppress     bool
-		adopted      bool
-		status       string
-		wantActivate bool
+		name          string
+		suppress      bool
+		alreadyExists bool
+		status        string
+		wantActivate  bool
 	}{
 		{
 			name:         "user staged by this call is activated",
@@ -714,10 +714,10 @@ func TestShouldActivateAfterCreate(t *testing.T) {
 			wantActivate: true,
 		},
 		{
-			name:     "adopted staged user is left untouched",
-			suppress: true,
-			adopted:  true,
-			status:   userStatusStaged,
+			name:          "already-existing staged user is left untouched",
+			suppress:      true,
+			alreadyExists: true,
+			status:        userStatusStaged,
 		},
 		{
 			name:     "activation not requested",
@@ -730,10 +730,10 @@ func TestShouldActivateAfterCreate(t *testing.T) {
 			status:   userStatusActive,
 		},
 		{
-			name:     "adopted active user is left untouched",
-			suppress: true,
-			adopted:  true,
-			status:   userStatusActive,
+			name:          "already-existing active user is left untouched",
+			suppress:      true,
+			alreadyExists: true,
+			status:        userStatusActive,
 		},
 	}
 
@@ -741,8 +741,8 @@ func TestShouldActivateAfterCreate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := shouldActivateAfterCreate(tt.suppress, tt.adopted, tt.status); got != tt.wantActivate {
-				t.Errorf("shouldActivateAfterCreate(%v, %v, %q) = %v, want %v", tt.suppress, tt.adopted, tt.status, got, tt.wantActivate)
+			if got := shouldActivateAfterCreate(tt.suppress, tt.alreadyExists, tt.status); got != tt.wantActivate {
+				t.Errorf("shouldActivateAfterCreate(%v, %v, %q) = %v, want %v", tt.suppress, tt.alreadyExists, tt.status, got, tt.wantActivate)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
- [x] Bug fix
- [ ] New feature

Two silent-success bugs in `CreateAccount`, both found while validating the account-creation profile fields that landed in #187.

**CXH-2201:** when a create with `send_activation_email=false` hits a duplicate login and the existing user is still `STAGED`, the connector adopts that user and then activates it. `STAGED` is also the intended end state of `create_inactive=true` (and of an admin-staged account), so a later unrelated create on the same login silently flipped a deliberately inactive account to active and reported success. Activation now runs only for a user this call just created; any duplicate login returns `AlreadyExistsResult` and leaves the existing user's lifecycle alone.

**CXH-2199:** `additionalAttributes` declared as a map in the creation schema was type-asserted and dropped on mismatch, with only a `Debug` log. Boolean profile fields in the same function already reject a wrong type. A wrong-typed value (for example a CEL mapping that returns a string) now fails the request instead of creating the account without the attributes the caller asked for.

### Sync:

- **Users** (`user`) — unchanged sync surface; both fixes are on the account-creation path only
- **Groups** (`group`) — unchanged
- **Roles** (`role`) — unchanged

### Provisioning:

- **Create user accounts** — (1) any duplicate login returns `AlreadyExistsResult` without mutating the existing user's lifecycle; activation runs only when `send_activation_email=false` for a user this call just staged. (2) `additionalAttributes` present with a non-object type returns an error; absent/null still means "no extra attributes". Protected-field override rejection is unchanged.
- **Grant/Revoke group membership** — unchanged
- **Grant/Revoke role assignment** — unchanged
- Idempotency: every duplicate-login conflict returns `AlreadyExistsResult` (with the existing Resource when the follow-up fetch succeeds; without Resource when lookup fails — the next sync correlates it)

### Auth:

Unchanged. No new config flags.

**Behavior note (not a config break):** a tenant whose account-creation mapping sends `additionalAttributes` as a non-object will start failing creates that previously succeeded while silently omitting those attributes. That is the intended fix for CXH-2199.

### Architecture highlights:

- Duplicate collisions return early as `AlreadyExistsResult`; activation is gated only by `suppressActivationEmail` on the happy-path create, so adoption cannot mutate lifecycle
- `STAGED` alone is not treated as proof of a stranded suppressed-email attempt (`create_inactive` and admin-staged accounts look identical)
- Trade-off vs the prior EDGE-02 convergence: a retry after a failed activation returns `AlreadyExistsResult` with the user still `STAGED`; finishing activation has to happen in Okta (`enable_user` only unsuspends `SUSPENDED` and swallows other statuses into an already-enabled success without changing the user)
- `parseObjectProfileField` mirrors `parseBoolProfileField`: absent/null → default, wrong type → error (same "never silently default" rule)
- Removed the pre-flight Debug-and-continue check on `additionalAttributes` in `CreateAccount`; validation lives in `getUserProfile` only

### Useful links:

- [Linear ticket CXH-2201 — deliberately staged account activated by later suppress create](https://linear.app/ductone/issue/CXH-2201/baton-okta-a-deliberately-staged-create-inactive-account-is-silently)
- [Linear ticket CXH-2199 — wrong-typed additionalAttributes silently dropped](https://linear.app/ductone/issue/CXH-2199/baton-okta-a-wrong-typed-additionalattributes-value-is-silently)
- [Okta Users API — Create User](https://developer.okta.com/docs/reference/api/users/#create-user)
- [Okta Users API — Activate User](https://developer.okta.com/docs/reference/api/users/#activate-user)
