### PR TITLE
CXH-2198: correct stale OAuth setup docs, add device and resource-set coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,16 @@ Notes for OAuth setup:
 ## docker
 
 ```
-docker run --rm -v $(pwd):/out -e BATON_API_TOKEN=oktaAPIToken -e BATON_DOMAIN=domain-1234.okta.com ghcr.io/conductorone/baton-okta:latest -f "/out/sync.c1z"
+docker run --rm -v $(pwd):/out -e BATON_API_TOKEN=oktaAPIToken -e BATON_DOMAIN=domain-1234.okta.com public.ecr.aws/conductorone/baton-okta:latest -f "/out/sync.c1z"
 docker run --rm -v $(pwd):/out ghcr.io/conductorone/baton:latest -f "/out/sync.c1z" resources
 ```
+
+The two images come from different registries, deliberately. Connector images are published
+to **ECR Public** (`public.ecr.aws/conductorone/baton-okta`), which is also what the
+Kubernetes manifests in [`docs/connector.mdx`](docs/connector.mdx) use. The `baton` CLI image
+is published only to **GHCR** (`ghcr.io/conductorone/baton`) — there is no
+`public.ecr.aws/conductorone/baton` repository, so do not "tidy" that second line to match
+the first.
 
 ## source
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ baton resources
 Notes for OAuth setup:
 
 - `BATON_AUTH_METHOD=private-key-group` is required when authenticating via OAuth — without it the CLI defaults to the API Token field group and refuses to start with `field api-token of type string is marked as required but it has a zero-value`.
-- The private key must be in **PKCS#1** PEM format (`-----BEGIN RSA PRIVATE KEY-----`). If `openssl genrsa` produced a PKCS#8 key (`-----BEGIN PRIVATE KEY-----`), convert it with `openssl rsa -in key.pem -out key.pkcs1.pem -traditional`.
-- See [`docs/connector.mdx`](docs/connector.mdx) for the complete Okta-side setup, including the required **disable DPoP** and admin-role assignment steps.
+- The private key must be a PEM-encoded **RSA** key. Both **PKCS#1** (`-----BEGIN RSA PRIVATE KEY-----`) and **PKCS#8** (`-----BEGIN PRIVATE KEY-----`, what `openssl genrsa` produces by default) are accepted, so no conversion step is needed. Elliptic-curve keys are rejected — Okta's DPoP implementation requires RSA.
+- **DPoP is supported** and needs no Okta-side change: leave the app's **Proof of Possession** setting at Okta's default. Earlier revisions of this file and of `docs/connector.mdx` told you to disable DPoP; that instruction described the pre-DPoP connector and was removed in CXH-2198.
+- The API Services app **must be assigned an admin role** on its **Admin Roles** tab. Granting OAuth scopes is not sufficient. Without a role, most endpoints return `403`, but `GET /api/v1/users` returns `200` with an empty list — so the sync succeeds and finds zero accounts.
+- See [`docs/connector.mdx`](docs/connector.mdx) for the complete Okta-side setup and [`docs/docs-info.md`](docs/docs-info.md) for the internal detail on key handling, DPoP, and scopes.
 
 ## docker
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -19,11 +19,17 @@ sidebarTitle: "Okta"
 | Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
 | Standard and custom admin roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |  |
+| Resource sets | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Resource set bindings | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
 | Secrets - API tokens | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |  |
 | Devices | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |  |
 
 <Note>
 **Devices is opt-in.** This resource type is off by default. Enable it by selecting the **Device** resource type in the connector's sync configuration. Devices are synced read-only; the connector does not manage device-to-user assignments.
+</Note>
+
+<Note>
+**Resource sets and resource set bindings require Sync Custom Roles.** These two resource types model Okta's custom-role machinery: a resource set is the collection of Okta objects a custom role applies to, and a binding pairs a resource set with a custom role. Granting a binding assigns a user or group to that custom role over that resource set. Both are synced and provisioned only when **Sync Custom Roles** is enabled.
 </Note>
 
 <Note>
@@ -259,9 +265,10 @@ On the app's **General** tab, note the **Client ID**.
 </Step>
 <Step>
 In the **Client Credentials** section, select **Public key / Private key** as the client authentication method.
-</Step>
-<Step>
-**Important: ensure DPoP is disabled.** In the same **Client Credentials** edit panel, locate the **Proof of Possession** option and confirm that **"Require Demonstrating Proof of Possession (DPoP) header in token requests"** is **unchecked**. Okta enables this by default for new API Services apps, but the connector does not currently support DPoP — leaving it on will cause every token request to fail with `"The DPoP proof JWT header is missing"`.
+
+<Note>
+**Leave the DPoP setting at its default.** The connector supports Demonstrating Proof of Possession (DPoP), so you do not need to change the **Proof of Possession** option — whether **"Require Demonstrating Proof of Possession (DPoP) header in token requests"** is checked (Okta's default for new API Services apps) or unchecked, the connector authenticates successfully. If you disabled DPoP for an existing app on the advice of an earlier version of this page, you can safely re-enable it.
+</Note>
 </Step>
 <Step>
 Click **Add Key**, then either generate a new key pair or paste your own public key. Save the private key securely — you'll need it when configuring the connector.
@@ -290,26 +297,28 @@ After clicking **Grant** for each scope, refresh the page and visually verify th
 Navigate to the **Admin Roles** tab and assign an appropriate admin role to the app (e.g., **Super Administrator** or a custom role with the permissions you need).
 
 <Note>
-Without an admin role assignment, the connector will fail with `"You do not have permission to perform the requested action"` (HTTP 403) on its first API call — even when all OAuth scopes are granted correctly.
+**This step is required, and skipping it does not always produce an error.** Granting OAuth scopes is not sufficient on its own — the scopes are present in the token, but Okta still evaluates the app's admin role when serving each request.
+
+Without an admin role assignment, and even when all OAuth scopes are granted correctly:
+
+- Most endpoints fail with `"You do not have permission to perform the requested action"` (HTTP 403). Device sync fails this way.
+- **User sync instead returns an empty list with HTTP 200.** The sync completes successfully and reports no error, but the connector finds zero accounts.
+
+If a sync finishes cleanly with no accounts, check the app's **Admin Roles** tab before looking anywhere else.
 </Note>
 </Step>
 </Steps>
 
 You'll need the **Client ID**, **Private Key**, and **Private Key ID** when configuring the connector.
 
-<Warning>
-**Private key format.** The connector requires the private key in **PKCS#1** PEM format — header line `-----BEGIN RSA PRIVATE KEY-----`.
+<Note>
+**Private key format.** The connector accepts a PEM-encoded **RSA** private key in either format, so no conversion is needed:
 
-OpenSSL 3.0+ produces **PKCS#8** by default — header line `-----BEGIN PRIVATE KEY-----` — which the connector will reject with `"RSA private key is of the wrong type"`.
+- **PKCS#1** — header line `-----BEGIN RSA PRIVATE KEY-----`
+- **PKCS#8** — header line `-----BEGIN PRIVATE KEY-----` (what OpenSSL 3.0+ produces by default)
 
-If your private key file starts with `-----BEGIN PRIVATE KEY-----`, convert it to PKCS#1 first:
-
-```bash
-openssl rsa -in your-key.pem -out your-key.pkcs1.pem -traditional
-```
-
-Use the contents of `your-key.pkcs1.pem` when configuring the connector.
-</Warning>
+The key must be RSA. Okta's DPoP implementation does not accept elliptic-curve keys, and the connector rejects an EC key with `"Okta DPoP requires RSA"`.
+</Note>
 
 ## Configure the Okta connector
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -13,6 +13,7 @@ Internal technical notes for maintainers. Customer-facing setup lives in [`docs/
    - **Roles** — Standard admin roles
    - **Custom roles / resource sets / bindings** — When `--sync-custom-roles` is enabled
    - **Secrets (API tokens)** — When `--sync-secrets` is enabled
+   - **Devices** — Okta-managed devices; **opt-in** resource type, off unless explicitly selected (see [Devices](#devices))
 
 2. Can the connector provision any resources? If so, which ones?
    - **User account creation** — `POST /api/v1/users` (+ optional `POST /api/v1/users/{id}/lifecycle/activate`)
@@ -35,13 +36,13 @@ Internal technical notes for maintainers. Customer-facing setup lives in [`docs/
 1. What credentials are needed?
    - **Domain** (`--domain` / `$BATON_DOMAIN`) — Okta org host, e.g. `acmeco.okta.com` or `integrator-123.okta.com`
    - **API Token** (`--api-token` / `$BATON_API_TOKEN`) — SSWS token, **or**
-   - **OAuth private key** — `--auth-method=private-key-group` plus `--okta-client-id`, `--okta-private-key-id`, `--okta-private-key` (PKCS#1 PEM)
+   - **OAuth private key** — `--auth-method=private-key-group` plus `--okta-client-id`, `--okta-private-key-id`, `--okta-private-key` (PEM-encoded RSA key; PKCS#1 or PKCS#8, see [OAuth private key handling](#oauth-private-key-handling))
 
 2. For each item:
 
    * **How does a user create or look up the credential?**
      - API token: Okta Admin → **Security** → **API** → **Tokens** → **Create Token**. See [`connector.mdx`](connector.mdx) Gather credentials.
-     - OAuth: Okta OIDC API Services app with private_key_jwt; DPoP must be disabled for the connector's JWT path unless DPoP support is configured. See [`connector.mdx`](connector.mdx).
+     - OAuth: Okta OIDC API Services app with private_key_jwt. DPoP is supported and needs no Okta-side change — leave the app's **Proof of Possession** setting at Okta's default. The app also needs an admin role on its **Admin Roles** tab; scopes alone are not enough. See [`connector.mdx`](connector.mdx) and [OAuth private key handling](#oauth-private-key-handling).
 
    * **Does it need specific scopes/permissions?**
      - Sync (read): `okta.users.read`, `okta.groups.read`, `okta.apps.read`, `okta.roles.read` (roles need elevated admin)
@@ -53,6 +54,34 @@ Internal technical notes for maintainers. Customer-facing setup lives in [`docs/
 
    * **What access is needed to CREATE the credential?**
      - Admin console access with permission to create API tokens or OIDC API Services apps (typically Super Admin or equivalent).
+
+---
+
+## OAuth private key handling
+
+The `private-key-group` auth path lives in `pkg/oktaauth` and is wired up by the `cfg.PrivateKeyGroup` branch of `pkg/connector/connector.go`.
+
+**DPoP is supported.** Added in CXH-1522 (PR #172, 2026-06-26). `oktaauth.NewDPoPHTTPClient` builds a DPoP proofer from the RSA key and returns an `*http.Client` whose round tripper handles the `DPoP-Nonce` challenge/retry exchange, with separate nonce stores for the token endpoint and resource endpoints. Both SDK clients (v2 and v5) are then constructed in `Bearer` authorization mode with a sentinel token, so the `oktaauth` transport owns authentication end to end rather than the SDK's native private-key path.
+
+Consequences for setup docs:
+
+- **No Okta-side DPoP change is needed.** The app works with **Require Demonstrating Proof of Possession (DPoP) header in token requests** either checked (Okta's default for new API Services apps) or unchecked. Documentation that instructs readers to disable DPoP is stale — it described the pre-CXH-1522 connector and was corrected in CXH-2198.
+- Verified live 2026-08-05 against `integrator-9077615.okta.com`: an API Services app with `dpop_bound_access_tokens: true` synced successfully both via the CLI binary and via the C1-hosted connector.
+
+**Key formats.** `parseRSAPrivateKey` accepts both PKCS#1 (`RSA PRIVATE KEY`) and PKCS#8 (`PRIVATE KEY`) PEM blocks, so no `openssl` conversion step is needed — earlier docs requiring PKCS#1 were stale. Literal `\n` sequences are normalized to real newlines before decoding, which is what lets an escaped single-line PEM survive being pasted through a config form (CXH-1910). The key must be RSA: a PKCS#8 block holding an EC key is rejected with `unsupported key type ...: Okta DPoP requires RSA`. Covered by `TestParseRSAPrivateKey` in `pkg/oktaauth/oktaauth_test.go`.
+
+**An admin role is required, and its absence is partly silent.** Scopes and admin role are evaluated independently: the requested scopes can all be present in the minted token while Okta still refuses the request because the API Services app has no role on its **Admin Roles** tab. Observed 2026-08-05 with `okta.devices.read` granted and present in the token, on an app with no admin role:
+
+| Call | Result |
+| :--- | :--- |
+| `GET /api/v1/devices` | `403` `E0000006` "You do not have permission to perform the requested action" |
+| `GET /api/v1/users` | `200` with an **empty list** |
+
+The users case is the dangerous one: the sync exits 0 and writes a bundle containing zero users, so a missing admin role presents as a successful empty sync rather than an error. Assigning Super Administrator makes both return data.
+
+**Requested scopes.** On this path the connector requests the four default read scopes plus all four `*.manage` provisioning scopes unconditionally, then adds `okta.apiTokens.read` when `--sync-secrets` is set and `okta.devices.read` when device sync is enabled. Per the note in `connector.go`, a scope the app has not been granted drops from the issued token and only surfaces as a 403 on first use, so a read-only app still authenticates.
+
+**Console caveat for whoever writes customer docs.** During CXH-2092 / CXH-2124 validation, the Okta Admin Console's **Okta API Scopes** tab twice failed to persist scope grants with no error shown — the grants did not appear in `GET /api/v1/apps/{id}/grants`. `POST /api/v1/apps/{id}/grants` worked reliably. The customer-facing walkthrough directs readers to that tab, so it carries a note telling them to refresh and visually confirm the granted scopes.
 
 ---
 
@@ -120,6 +149,7 @@ Doc roots:
 - [Groups](https://developer.okta.com/docs/reference/api/groups/)
 - [Apps](https://developer.okta.com/docs/reference/api/apps/)
 - [Roles](https://developer.okta.com/docs/reference/api/roles/)
+- [Devices](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/)
 - [Authorization Servers / OAuth for Okta](https://developer.okta.com/docs/guides/implement-oauth-for-okta/)
 
 ### Users
@@ -147,6 +177,47 @@ Doc roots:
 | :--- | :--- | :--- |
 | List apps | `GET /api/v1/apps` | [List Applications](https://developer.okta.com/docs/reference/api/apps/#list-applications) |
 | Assign / unassign user | app users assign/unassign | [Assign User](https://developer.okta.com/docs/reference/api/apps/#assign-user-to-application-for-sso) |
+
+### Devices
+
+Added in v0.5.19 (PR #186, CXH-2092). Implemented in `pkg/connector/device.go`; resource type declared in `pkg/connector/connector.go`.
+
+**Opt-in.** The resource type carries an `&v2.OptInRequired{}` annotation, so it is off unless the sync filter explicitly selects `device` — `shouldSyncResourceType` requires an explicit filter that names the type. It is registered unconditionally (not behind a config flag), so it always appears in the capabilities/metadata output and reaches the C1 platform for a user to enable.
+
+**Read-only.** `Entitlements` and `Grants` both return `nil` — devices are synced as inventory only. Device-to-user assignments are **not** modelled, so there is nothing to review or provision against a device.
+
+| Property | Value |
+| :--- | :--- |
+| Resource type ID | `device` |
+| Display name | `Device` |
+| Trait | `TRAIT_MANAGED_DEVICE` (built with `resource.NewManagedDeviceResource`) |
+| Required scope | `okta.devices.read` |
+| Provisioning | None (no entitlements, no grants) |
+
+| Operation | Method + path | Doc |
+| :--- | :--- | :--- |
+| List devices | `GET /api/v1/devices` | [List Devices](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/#tag/Device/operation/listDevices) |
+
+Called through okta-sdk-golang **v5** (`DeviceAPI.ListDevices`), unlike most of the connector, which is on v2.
+
+**Pagination.** `limit` is clamped to `deviceListLimit = 200`, Okta's enforced maximum for this endpoint; a larger requested page size is silently reduced to 200. Paging follows Okta's Link-header cursor: the first call issues `ListDevices`, and each subsequent page is fetched by deserializing the previous `APIResponse` out of the page-token bag and calling `.Next()`.
+
+**Field mapping.** All attributes come from the device's `profile` object. When `profile` is absent, no trait options are set and the resource name falls back to the device ID.
+
+| Okta field | Baton managed-device field |
+| :--- | :--- |
+| `id` (top level) | Resource ID |
+| `profile.displayName` | Resource display name (falls back to `id` when empty) |
+| `profile.serialNumber` | Serial |
+| `profile.udid` | UDID |
+| `profile.model` | Model |
+| `profile.manufacturer` | Vendor |
+| `profile.platform` | OS name, plus the mapped OS type below |
+| `profile.osVersion` | OS version |
+
+**Platform mapping.** `WINDOWS`, `MACOS`, `IOS`, `ANDROID`, and `CHROMEOS` map to their `DeviceOS_OsType` equivalents. Any other value maps to `OS_TYPE_UNSPECIFIED` — deliberately left unset rather than guessed — while `profile.platform` is still carried through verbatim as the OS name, so a new Okta platform value surfaces as an unspecified type with a readable name.
+
+**Failure mode.** On the OAuth path, `okta.devices.read` is only appended to the requested token scopes when device sync is enabled. Granting the scope is not sufficient by itself: with the scope present in the token but no admin role on the API Services app, `GET /api/v1/devices` returns `403 E0000006` (verified live 2026-08-05). See [OAuth private key handling](#oauth-private-key-handling).
 
 ---
 


### PR DESCRIPTION
Docs-only. Fixes the four findings in [CXH-2198](https://linear.app/ductone/issue/CXH-2198/), found while validating CXH-2092 (devices) and CXH-2124 (account-creation profile fields).

## Why this matters

The OAuth 2.0 walkthrough told readers to **disable DPoP** on their Okta app, citing a connector limitation that CXH-1522 (PR #172) removed. Anyone following the published page turned off Okta's default proof-of-possession protection for no reason. The same section required a PKCS#1 private key and prescribed an `openssl` conversion; both formats have been accepted since that same change.

## Changes

### `docs/connector.mdx`
- **Removed the "ensure DPoP is disabled" step.** DPoP is supported — `pkg/oktaauth` builds a DPoP-aware client and the `PrivateKeyGroup` branch of `pkg/connector/connector.go` uses it. Replaced with a note saying no Okta-side change is needed, and that a reader who previously disabled DPoP on this page's advice can safely re-enable it.
- **Corrected the private-key format note.** `parseRSAPrivateKey` accepts both PKCS#1 and PKCS#8 RSA keys. RSA is still required; EC keys are rejected.
- **Expanded the admin-role note.** It documented only the 403. A missing admin role also makes `GET /api/v1/users` return `200` with an empty list, so the sync exits 0 having found zero accounts — a silent failure worth calling out explicitly.
- **Added Resource sets and Resource set bindings** to the capabilities table. Both declare `CAPABILITY_PROVISION` and implement `Grant`/`Revoke`, and both require **Sync Custom Roles**.

### `docs/docs-info.md`
- **Added a Devices section** — the file had no device content since the resource type shipped in v0.5.19. Covers opt-in mechanics, read-only sync, the v5 SDK endpoint, the 200-item `limit` clamp, Link-header paging, field mapping, and platform mapping.
- **Added an OAuth private key handling section** covering DPoP, key formats, the admin-role requirement, and requested scopes.

### `README.md`
- Corrected the same DPoP and PKCS#1 claims; added the admin-role requirement.
- **Pointed the docker quickstart at ECR Public.** It pulled `ghcr.io/conductorone/baton-okta`, which stopped receiving builds at 0.5.7 while ECR Public is at 0.5.21. Since `pkg/oktaauth` first shipped in v0.5.11, every GHCR image predates DPoP support — a self-hosted reader following this file would hit the exact failure whose workaround this PR deletes as stale.

## Two ticket findings needed no change

CXH-2198 also reported the OAuth admin-role step and the Devices capability row as missing. Both were already in the repo — the admin-role step since 2026-05-11 (`ccfc4e589`) and the Devices row since 2026-08-03 (`358c858dc`, PR #186). Those are docs publish lag, not repo drift. The silent empty-user-list behaviour was genuinely undocumented, so that part was added.

## Verification

- `go test ./pkg/oktaauth/ -run TestParseRSAPrivateKey -v` — passes, including a `PKCS8_RSA` case asserting acceptance and a `PKCS8_ECDSA` case asserting the RSA-only rejection.
- DPoP behaviour verified live 2026-08-05 against `integrator-9077615.okta.com`: an API Services app with `dpop_bound_access_tokens: true` synced successfully on both the CLI binary and the C1-hosted connector.
- Admin-role behaviour verified the same day: with `okta.devices.read` granted and present in the token but no admin role, `/api/v1/devices` returned `403 E0000006` and `/api/v1/users` returned `200` with an empty list. Assigning Super Administrator made both return data.
- Registry claims verified against both registry APIs with pagination followed to completion — `tags/list` returns only the first 100 entries by default, which understates GHCR's newest tag if you do not follow `Link: rel="next"`. ECR Public: 101 tags, max release 0.5.21. GHCR: 281 tags, max release 0.5.7.
- Only the connector image line moved. `public.ecr.aws/conductorone/baton` returns `NAME_UNKNOWN`; the `baton` CLI image is published only to GHCR, where `:latest` is 0.4.5, matching the CLI's current release. A note records that split so the CLI line is not "fixed" to match the connector line.
- MDX structure checked: 5/5 frontmatter keys, all components balanced, both config tabs present, internal anchors resolve, external Okta doc links return 200.

## Follow-up worth a separate ticket

GHCR publishing for `baton-okta` stopped around 0.5.7 while the README kept pointing there. That is a release-pipeline question rather than a docs one, and other `baton-*` repos may still document GHCR — worth a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)