### PR TITLE
[CXH-2223] - Recover stranded staged accounts through lifecycle actions - Okta Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ With `--provisioning` enabled, the connector supports:
 - **Account creation** — create Okta users via C1 account provisioning / `--create-account-profile`
 - **Group / app / role grant and revoke**
 - **Group create, modify, and delete** (group delete via `--delete-resource`)
-- **enable_user / disable_user** lifecycle actions
+- **enable_user / disable_user** lifecycle actions — `enable_user` unsuspends a `SUSPENDED` account and activates a `STAGED` one (no activation email); `disable_user` suspends an enabled account
 
 ### Account creation profile fields
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ With `--provisioning` enabled, the connector supports:
 
 Okta `STAGED` users (created but not activated — cannot sign in to Okta) sync as disabled in C1, aligned with those lifecycle actions. See [docs/docs-info.md](docs/docs-info.md#lifecycle-actions) and [docs/connector.mdx](docs/connector.mdx).
 
+### Account creation profile fields
+
 Optional keys in the account creation profile (see [docs/connector.mdx](docs/connector.mdx) for field semantics and [docs/docs-info.md](docs/docs-info.md) for wire-level detail):
 
 | Key | Values | Notes |

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -82,8 +82,8 @@ Connector actions are custom capabilities that extend C1 automations with app-sp
 
 | Action name | Additional fields | Description |
 |-------------|-------------------|-------------|
-| enable_user | `user_id` (string, required) | Unsuspends a suspended Okta user account |
-| disable_user     | `user_id` (string, required) | Suspends an active Okta user account |
+| enable_user | `user_id` (string, required) | Enables an Okta user account: unsuspends a suspended account, and activates a staged one without sending an activation email. Returns success without calling Okta when the account is already enabled. |
+| disable_user     | `user_id` (string, required) | Suspends an Okta user account. Returns success without calling Okta when the account is already suspended, deactivated, or still staged. |
 | create | `name` (string, required), `description` (string), `userMembers` (resource ID list) | Creates a new Okta group with optional initial members |
 | modify_group | `group_id` (string, required), `name` (string), `description` (string) | Updates the name and/or description of an existing Okta group. Returns success without calling the Okta API if the supplied values already match the group's current name and description (idempotent). |
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -69,6 +69,10 @@ When you configure account provisioning for Okta, C1 shows the following optiona
 </Note>
 
 <Note>
+Okta **Staged** users sync as disabled in C1. In Okta, staged means the account was created but not activated yet, so nobody can sign in. That matches the lifecycle actions: `disable_user` is a no-op on staged accounts, and `enable_user` activates them. After you upgrade a connector that previously reported staged users as enabled, the next sync flips those resources to disabled — review any automations that key off user enabled/disabled status.
+</Note>
+
+<Note>
 If you map one of these fields to an expression, make sure the expression returns the field's type: **Additional Attributes** must return a map, and the `True` / `False` fields must return a boolean. Account creation fails with an error when a mapped value has the wrong type, so the account is never created without the values you asked for. Leaving a field unmapped uses its default.
 </Note>
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -88,7 +88,7 @@ Connector actions are custom capabilities that extend C1 automations with app-sp
 
 | Action name | Additional fields | Description |
 |-------------|-------------------|-------------|
-| enable_user | `user_id` (string, required) | Enables an Okta user account: unsuspends a suspended account, and activates a staged one without sending an activation email. Returns success without calling Okta when the account is already enabled. |
+| enable_user | `user_id` (string, required) | Enables an Okta user account: unsuspends a suspended account, and activates a staged one without sending an activation email. Returns success without calling Okta when the account is already enabled. Does **not** reactivate a deactivated (`DEPROVISIONED`) account — that returns an error. Okta's activate API can do that transition, but this action treats reactivation of a deactivated user as a separate decision from enable. |
 | disable_user     | `user_id` (string, required) | Suspends an Okta user account. Returns success without calling Okta when the account is already suspended, deactivated, or still staged. |
 | create | `name` (string, required), `description` (string), `userMembers` (resource ID list) | Creates a new Okta group with optional initial members |
 | modify_group | `group_id` (string, required), `name` (string), `description` (string) | Updates the name and/or description of an existing Okta group. Returns success without calling the Okta API if the supplied values already match the group's current name and description (idempotent). |

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -22,7 +22,7 @@ Internal technical notes for maintainers. Customer-facing setup lives in [`docs/
    - **Role assignment** — Grant/Revoke for assignable roles
    - **Custom-role bindings** — Grant/Revoke on resource-set bindings when custom roles are enabled
    - **Group create / modify / delete** — Resource actions + `ResourceDeleter` for groups
-   - **enable_user / disable_user** — Lifecycle actions (unsuspend / suspend)
+   - **enable_user / disable_user** — Lifecycle actions (activate / unsuspend / suspend, see [Lifecycle actions](#lifecycle-actions))
 
    **Note:** Account **deprovisioning** (hard delete of users) is not implemented. Soft disable is via `disable_user`.
 
@@ -139,11 +139,13 @@ The existing user's lifecycle is never changed — activation runs only for a us
 created. `STAGED` does not identify a stranded attempt: `create_inactive=true` and an admin-staged
 account look identical, so activating on a duplicate would override an explicit "keep this account
 inactive" decision. The trade-off is that a retry after a failed activation reports
-`AlreadyExistsResult` with the user still `STAGED`, and finishing activation has to happen in Okta.
-The `enable_user` action does not cover this case: it only unsuspends a `SUSPENDED` user. On any other
-status (including `STAGED`) Okta returns "Cannot unsuspend a user that is not suspended", and the
-action swallows that into a success response (`Account … was already enabled`) without changing the
-user — so the account stays `STAGED`.
+`AlreadyExistsResult` with the user still `STAGED`.
+
+Finishing that activation is an explicit operation: run the `enable_user` action against the
+account, which activates a `STAGED` user with `sendEmail=false` (see
+[Lifecycle actions](#lifecycle-actions)). A repeated create will not do it, by design — only an
+operator asking to enable that specific account can, because a create cannot tell a stranded
+attempt from a deliberately inactive account.
 
 ### Org2Org / hub-spoke
 
@@ -154,6 +156,35 @@ Spoke users are often created as `FEDERATION` (hub owns credentials) with `send_
 - FEDERATION user after staged create + activate(`sendEmail=false`) → typically **ACTIVE**.
 - OKTA user with **no password** after the same flow → typically **PROVISIONED** (same as default create without password).
 - OKTA user **with** password after activate(`sendEmail=false`) → typically **ACTIVE**.
+
+---
+
+## Lifecycle actions
+
+`enable_user` and `disable_user` both read the account's current Okta status first, because each
+Okta lifecycle endpoint accepts a single source status — `unsuspend` only applies to `SUSPENDED`
+and `activate` only to `STAGED`. What each status does:
+
+| Okta status | `enable_user` | `disable_user` |
+|---|---|---|
+| `ACTIVE`, `PROVISIONED`, `RECOVERY`, `PASSWORD_EXPIRED`, `LOCKED_OUT` | already enabled, no call | `POST /lifecycle/suspend` |
+| `SUSPENDED` | `POST /lifecycle/unsuspend` | already disabled, no call |
+| `STAGED` | `POST /lifecycle/activate?sendEmail=false` | already disabled, no call |
+| `DEPROVISIONED` | error — reactivating a deactivated account is a separate decision | already disabled, no call |
+
+Both actions re-read the account after the call and report the resulting Okta status in the
+response message. A call that Okta rejects is returned as an error unless the re-read shows the
+account is in the requested state anyway (a concurrent change). Neither action reports success
+about an account it did not verify: `enable_user` on a `STAGED` account used to return
+`Account … was already enabled` while the account stayed `STAGED` and unusable.
+
+`RECOVERY`, `PASSWORD_EXPIRED` and `LOCKED_OUT` are credential problems on an account that is
+enabled, so `enable_user` reports them as already enabled rather than clearing them — neither
+unlocking nor a password reset is part of this action.
+
+`activate` sends no email, matching the `send_activation_email=false` create path. An `OKTA`
+account without a password typically lands in `PROVISIONED`, while a `FEDERATION` account can land
+in `ACTIVE`; the response message names the status Okta actually returns.
 
 ---
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -172,11 +172,12 @@ and `activate` only to `STAGED`. What each status does:
 | `STAGED` | `POST /lifecycle/activate?sendEmail=false` | already disabled, no call |
 | `DEPROVISIONED` | error — reactivating a deactivated account is a separate decision | already disabled, no call |
 
-Both actions re-read the account after the call and report the resulting Okta status in the
-response message. A call that Okta rejects is returned as an error unless the re-read shows the
-account is in the requested state anyway (a concurrent change). Neither action reports success
-about an account it did not verify: `enable_user` on a `STAGED` account used to return
-`Account … was already enabled` while the account stayed `STAGED` and unusable.
+Both actions plan from a single status GET, then trust a successful lifecycle call — they do
+not re-read the account afterward. C1 runs each action in a fresh lambda, so adding vendor-SDK
+cache bypass just to support a confirm GET is unnecessary; the mutation response is the proof.
+A call Okta rejects is returned as an error. Neither action invents success from a string-matched
+vendor error: `enable_user` on a `STAGED` account used to return `Account … was already enabled`
+while the account stayed `STAGED` and unusable.
 
 `RECOVERY`, `PASSWORD_EXPIRED` and `LOCKED_OUT` are credential problems on an account that is
 enabled, so `enable_user` reports them as already enabled rather than clearing them — neither
@@ -184,7 +185,7 @@ unlocking nor a password reset is part of this action.
 
 `activate` sends no email, matching the `send_activation_email=false` create path. An `OKTA`
 account without a password typically lands in `PROVISIONED`, while a `FEDERATION` account can land
-in `ACTIVE`; the response message names the status Okta actually returns.
+in `ACTIVE`; the action success message no longer names that post-transition status.
 
 ---
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -172,14 +172,14 @@ and `activate` only to `STAGED`. What each status does:
 | `STAGED` | `POST /lifecycle/activate?sendEmail=false` | already disabled, no call |
 | `DEPROVISIONED` | error — reactivating a deactivated account is a separate decision | already disabled, no call |
 
-**Sync vs actions on `STAGED` (intentional divergence).** Sync still maps `STAGED` →
-`RESOURCE_STATUS_ENABLED` in `userResource` — that contract predates this PR and is unchanged
-(flipping it to disabled would re-key status for existing tenants). Lifecycle actions use a
-different lens: "can someone sign in / which Okta endpoint applies?" A staged account cannot
-sign in, so `disable_user` treats it as already disabled (no-op) while `enable_user` activates
-it. Operators can therefore see the resource as enabled in C1 while `disable_user` reports
-already-disabled and only `enable_user` moves the account out of `STAGED`. That wrinkle is
-expected; do not "fix" it by changing the sync mapping in an actions PR.
+**Sync status for `STAGED`.** Sync maps `STAGED` → `RESOURCE_STATUS_DISABLED` (same bucket as
+`SUSPENDED` / `DEPROVISIONED`). In Okta, staged means the account was created but not activated —
+nobody can sign in until `activate`. That matches lifecycle actions (`disable_user` is a no-op;
+`enable_user` activates) and the customer-facing create-inactive wording ("staged (inactive)").
+The previous sync mapping of `STAGED` → `ENABLED` came from an early default ("only
+suspended/deprovisioned are disabled") and was never an Okta-accurate design; aligning sync
+here is a visible status flip for any tenant that still has staged users. `PROVISIONED` stays
+`ENABLED`: activation already happened and the account is only pending user action.
 
 Both actions plan from a single status GET, then trust a successful lifecycle call — they do
 not re-read the account afterward. C1 runs each action in a fresh lambda, so adding vendor-SDK

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -172,6 +172,15 @@ and `activate` only to `STAGED`. What each status does:
 | `STAGED` | `POST /lifecycle/activate?sendEmail=false` | already disabled, no call |
 | `DEPROVISIONED` | error — reactivating a deactivated account is a separate decision | already disabled, no call |
 
+**Sync vs actions on `STAGED` (intentional divergence).** Sync still maps `STAGED` →
+`RESOURCE_STATUS_ENABLED` in `userResource` — that contract predates this PR and is unchanged
+(flipping it to disabled would re-key status for existing tenants). Lifecycle actions use a
+different lens: "can someone sign in / which Okta endpoint applies?" A staged account cannot
+sign in, so `disable_user` treats it as already disabled (no-op) while `enable_user` activates
+it. Operators can therefore see the resource as enabled in C1 while `disable_user` reports
+already-disabled and only `enable_user` moves the account out of `STAGED`. That wrinkle is
+expected; do not "fix" it by changing the sync mapping in an actions PR.
+
 Both actions plan from a single status GET, then trust a successful lifecycle call — they do
 not re-read the account afterward. C1 runs each action in a fresh lambda, so adding vendor-SDK
 cache bypass just to support a confirm GET is unnecessary; the mutation response is the proof.

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -3,14 +3,16 @@ package connector
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	config "github.com/conductorone/baton-sdk/pb/c1/config/v1"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"github.com/okta/okta-sdk-golang/v2/okta"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -80,70 +82,141 @@ func (o *Okta) GlobalActions(ctx context.Context, registry actions.ActionRegistr
 	return nil
 }
 
-// enableUser "unsuspends" the subject Okta account.
-//
-// It requires the "user_id" field to be provided in the arguments struct,
-// corresponding to the Okta user to be unsuspended.
-//
-// If the account is already active or not suspended, no error is returned and success is indicated.
-// If unsuspension is successful or the status is already correct, a success response
-// is returned. If any other error occurs during the unsuspension process, it is returned.
-func (o *Okta) enableUser(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
+// lifecycleTransitionFunc is one Okta lifecycle call (activate, unsuspend, suspend).
+type lifecycleTransitionFunc func(ctx context.Context, client *okta.Client, oktaUserID string) error
 
-	oktaUserID, err := extractFieldAsString(args, "user_id")
-	if err != nil {
-		return nil, nil, err
-	}
-	l.Debug("enabling account", zap.String("oktaUserID", oktaUserID))
+// lifecyclePlan is how an action treats the account's current Okta status.
+type lifecyclePlan int
 
-	err = unsuspendUser(ctx, o.client, oktaUserID)
-	if err != nil {
-		// if user is already active, do not surface the error and instead respond with
-		// success since the state of the account matches the requested state
-		if strings.Contains(err.Error(), "Cannot unsuspend a user that is not suspended") {
-			// TODO: Update baton-sdk to handle an annotation in order to notify the
-			// user that the user is already active.
-			l.Debug("user is already enabled", zap.String("oktaUserID", oktaUserID))
-			return createSuccessResponse(fmt.Sprintf("Account %s was already enabled", oktaUserID)), nil, nil
+const (
+	planAlreadySatisfied lifecyclePlan = iota // already in the requested state
+	planTransition                            // call a lifecycle endpoint
+	planUnsupported                           // no transition this action supports
+)
+
+// planUserLifecycle selects the Okta endpoint for the requested enabled state.
+func planUserLifecycle(oktaStatus string, enabled bool) (lifecyclePlan, lifecycleTransitionFunc) {
+	if enabled {
+		switch oktaStatus {
+		case userStatusStaged:
+			return planTransition, activateUser
+		case userStatusSuspended:
+			return planTransition, unsuspendUser
+		default:
+			if isEnabledOktaStatus(oktaStatus) {
+				return planAlreadySatisfied, nil
+			}
 		}
-
-		return nil, nil, err
+		return planUnsupported, nil
 	}
 
-	return createSuccessResponse(fmt.Sprintf("Account %s has been successfully enabled", oktaUserID)), nil, nil
+	if isDisabledOktaStatus(oktaStatus) {
+		return planAlreadySatisfied, nil
+	}
+	if isEnabledOktaStatus(oktaStatus) {
+		return planTransition, suspendUser
+	}
+	return planUnsupported, nil
 }
 
-// disableUser suspends the subject Okta account.
-//
-// It requires the "user_id" field to be provided in the arguments struct,
-// corresponding to the Okta user to be suspended.
-//
-// If the user is already suspended, no error is returned and success is indicated.
-// If suspension is successful or the status is already correct, a success response
-// is returned. If any other error occurs during the suspension process, it is returned.
+func isRequestedOktaStatus(oktaStatus string, enabled bool) bool {
+	if enabled {
+		return isEnabledOktaStatus(oktaStatus)
+	}
+	return isDisabledOktaStatus(oktaStatus)
+}
+
+// enableUser activates a STAGED account or unsuspends a SUSPENDED one. Requires user_id.
+// Already-enabled accounts succeed without calling Okta.
+func (o *Okta) enableUser(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+	return o.setUserEnabled(ctx, args, true)
+}
+
+// disableUser suspends the subject Okta account. Requires user_id. Accounts nobody can
+// sign in to succeed without calling Okta.
 func (o *Okta) disableUser(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+	return o.setUserEnabled(ctx, args, false)
+}
+
+// setUserEnabled reads status, applies the required Okta transition, and confirms it.
+// Okta lifecycle endpoints each accept one source status; success names the status
+// the account actually reached.
+func (o *Okta) setUserEnabled(ctx context.Context, args *structpb.Struct, enabled bool) (*structpb.Struct, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
 	oktaUserID, err := extractFieldAsString(args, "user_id")
 	if err != nil {
 		return nil, nil, err
 	}
-	l.Debug("disabling account", zap.String("oktaUserID", oktaUserID))
+	verb := "disable"
+	pastTense := "disabled"
+	if enabled {
+		verb = "enable"
+		pastTense = "enabled"
+	}
+	l.Debug("running account lifecycle action",
+		zap.String("action", verb),
+		zap.String("oktaUserID", oktaUserID),
+	)
 
-	err = suspendUser(ctx, o.client, oktaUserID)
+	currentStatus, err := o.userStatus(ctx, oktaUserID)
 	if err != nil {
-		// if user is already suspended, do not surface the error and instead respond
-		// with success since the state of the account matches the requested state
-		if strings.Contains(err.Error(), "Cannot suspend a user that is not active") {
-			// TODO: Update baton-sdk to handle an annotation in order to notify the
-			// user that the user is already suspended.
-			l.Debug("user is already suspended", zap.String("oktaUserID", oktaUserID))
-			return createSuccessResponse(fmt.Sprintf("Account %s was already disabled", oktaUserID)), nil, nil
-		}
-
 		return nil, nil, err
 	}
 
-	return createSuccessResponse(fmt.Sprintf("Account %s has been successfully disabled", oktaUserID)), nil, nil
+	plan, transition := planUserLifecycle(currentStatus, enabled)
+	switch plan {
+	case planAlreadySatisfied:
+		return createSuccessResponse(fmt.Sprintf("Account %s was already %s (Okta status %s)", oktaUserID, pastTense, currentStatus)), nil, nil
+	case planUnsupported:
+		return nil, nil, status.Errorf(
+			codes.FailedPrecondition,
+			"okta-connectorv2: cannot %s user %s from Okta status %s",
+			verb, oktaUserID, currentStatus,
+		)
+	case planTransition:
+		// fall through
+	}
+
+	if err := transition(ctx, o.client, oktaUserID); err != nil {
+		// Concurrent change may reject the call while the account is already satisfied.
+		finalStatus, statusErr := o.userStatus(ctx, oktaUserID)
+		if statusErr != nil || !isRequestedOktaStatus(finalStatus, enabled) {
+			return nil, nil, err
+		}
+		l.Debug("lifecycle call failed but the account is in the requested state",
+			zap.String("action", verb),
+			zap.String("oktaUserID", oktaUserID),
+			zap.String("okta_status", finalStatus),
+			zap.Error(err),
+		)
+		return createSuccessResponse(fmt.Sprintf("Account %s was already %s (Okta status %s)", oktaUserID, pastTense, finalStatus)), nil, nil
+	}
+
+	finalStatus, err := o.userStatus(ctx, oktaUserID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !isRequestedOktaStatus(finalStatus, enabled) {
+		return nil, nil, status.Errorf(
+			codes.Internal,
+			"okta-connectorv2: %s of user %s returned success but the account is in Okta status %s",
+			verb, oktaUserID, finalStatus,
+		)
+	}
+
+	return createSuccessResponse(fmt.Sprintf("Account %s has been successfully %s (Okta status %s)", oktaUserID, pastTense, finalStatus)), nil, nil
+}
+
+// userStatus returns the live Okta lifecycle status (uncached).
+func (o *Okta) userStatus(ctx context.Context, oktaUserID string) (string, error) {
+	user, _, err := getUserUncached(ctx, o.client, oktaUserID)
+	if err != nil {
+		return "", fmt.Errorf("okta-connectorv2: failed to find user %s: %w", oktaUserID, err)
+	}
+	if user == nil {
+		return "", status.Errorf(codes.NotFound, "okta-connectorv2: user %s not found", oktaUserID)
+	}
+
+	return user.Status, nil
 }

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -119,13 +119,6 @@ func planUserLifecycle(oktaStatus string, enabled bool) (lifecyclePlan, lifecycl
 	return planUnsupported, nil
 }
 
-func isRequestedOktaStatus(oktaStatus string, enabled bool) bool {
-	if enabled {
-		return isEnabledOktaStatus(oktaStatus)
-	}
-	return isDisabledOktaStatus(oktaStatus)
-}
-
 // enableUser activates a STAGED account or unsuspends a SUSPENDED one. Requires user_id.
 // Already-enabled accounts succeed without calling Okta.
 func (o *Okta) enableUser(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
@@ -138,9 +131,9 @@ func (o *Okta) disableUser(ctx context.Context, args *structpb.Struct) (*structp
 	return o.applyUserLifecycle(ctx, args, false)
 }
 
-// applyUserLifecycle reads status, applies the required Okta transition, and confirms it.
-// Okta lifecycle endpoints each accept one source status; success names the status
-// the account actually reached. enabled=true enables; enabled=false disables.
+// applyUserLifecycle reads status and applies the required Okta transition.
+// Okta lifecycle endpoints each accept one source status. enabled=true enables;
+// enabled=false disables.
 func (o *Okta) applyUserLifecycle(ctx context.Context, args *structpb.Struct, enabled bool) (*structpb.Struct, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
@@ -179,38 +172,15 @@ func (o *Okta) applyUserLifecycle(ctx context.Context, args *structpb.Struct, en
 	}
 
 	if err := transition(ctx, o.client, oktaUserID); err != nil {
-		// Concurrent change may reject the call while the account is already satisfied.
-		finalStatus, statusErr := o.userStatus(ctx, oktaUserID)
-		if statusErr != nil || !isRequestedOktaStatus(finalStatus, enabled) {
-			return nil, nil, err
-		}
-		l.Debug("lifecycle call failed but the account is in the requested state",
-			zap.String("action", verb),
-			zap.String("oktaUserID", oktaUserID),
-			zap.String("okta_status", finalStatus),
-			zap.Error(err),
-		)
-		return createSuccessResponse(fmt.Sprintf("Account %s was already %s (Okta status %s)", oktaUserID, pastTense, finalStatus)), nil, nil
-	}
-
-	finalStatus, err := o.userStatus(ctx, oktaUserID)
-	if err != nil {
 		return nil, nil, err
 	}
-	if !isRequestedOktaStatus(finalStatus, enabled) {
-		return nil, nil, status.Errorf(
-			codes.Internal,
-			"okta-connectorv2: %s of user %s returned success but the account is in Okta status %s",
-			verb, oktaUserID, finalStatus,
-		)
-	}
 
-	return createSuccessResponse(fmt.Sprintf("Account %s has been successfully %s (Okta status %s)", oktaUserID, pastTense, finalStatus)), nil, nil
+	return createSuccessResponse(fmt.Sprintf("Account %s has been successfully %s", oktaUserID, pastTense)), nil, nil
 }
 
-// userStatus returns the live Okta lifecycle status (uncached).
+// userStatus returns the Okta lifecycle status used to plan the action.
 func (o *Okta) userStatus(ctx context.Context, oktaUserID string) (string, error) {
-	user, _, err := getUserUncached(ctx, o.client, oktaUserID)
+	user, _, err := getUser(ctx, o.client, oktaUserID)
 	if err != nil {
 		return "", fmt.Errorf("okta-connectorv2: failed to find user %s: %w", oktaUserID, err)
 	}

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -129,19 +129,19 @@ func isRequestedOktaStatus(oktaStatus string, enabled bool) bool {
 // enableUser activates a STAGED account or unsuspends a SUSPENDED one. Requires user_id.
 // Already-enabled accounts succeed without calling Okta.
 func (o *Okta) enableUser(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
-	return o.setUserEnabled(ctx, args, true)
+	return o.applyUserLifecycle(ctx, args, true)
 }
 
 // disableUser suspends the subject Okta account. Requires user_id. Accounts nobody can
 // sign in to succeed without calling Okta.
 func (o *Okta) disableUser(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
-	return o.setUserEnabled(ctx, args, false)
+	return o.applyUserLifecycle(ctx, args, false)
 }
 
-// setUserEnabled reads status, applies the required Okta transition, and confirms it.
+// applyUserLifecycle reads status, applies the required Okta transition, and confirms it.
 // Okta lifecycle endpoints each accept one source status; success names the status
-// the account actually reached.
-func (o *Okta) setUserEnabled(ctx context.Context, args *structpb.Struct, enabled bool) (*structpb.Struct, annotations.Annotations, error) {
+// the account actually reached. enabled=true enables; enabled=false disables.
+func (o *Okta) applyUserLifecycle(ctx context.Context, args *structpb.Struct, enabled bool) (*structpb.Struct, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
 	oktaUserID, err := extractFieldAsString(args, "user_id")

--- a/pkg/connector/actions_test.go
+++ b/pkg/connector/actions_test.go
@@ -1,0 +1,90 @@
+package connector
+
+import (
+	"testing"
+)
+
+// allOktaUserStatuses is spelled out (not derived) so a status added to only one
+// of enabled/disabled fails TestOktaStatusPredicates_Partition.
+var allOktaUserStatuses = []string{
+	userStatusActive,
+	userStatusProvisioned,
+	userStatusRecovery,
+	userStatusPasswordExpired,
+	userStatusLockedOut,
+	userStatusStaged,
+	userStatusSuspended,
+	userStatusDeprovisioned,
+}
+
+func TestOktaStatusPredicates_Partition(t *testing.T) {
+	t.Parallel()
+
+	for _, oktaStatus := range allOktaUserStatuses {
+		t.Run(oktaStatus, func(t *testing.T) {
+			t.Parallel()
+
+			enabled := isEnabledOktaStatus(oktaStatus)
+			disabled := isDisabledOktaStatus(oktaStatus)
+			if enabled == disabled {
+				t.Fatalf("status %s must be exactly one of enabled/disabled, got enabled=%v disabled=%v", oktaStatus, enabled, disabled)
+			}
+		})
+	}
+
+	t.Run("unknown status is neither", func(t *testing.T) {
+		t.Parallel()
+
+		const unknown = "NOT_A_STATUS"
+		if isEnabledOktaStatus(unknown) || isDisabledOktaStatus(unknown) {
+			t.Fatal("unrecognized status must not be classified")
+		}
+	})
+}
+
+// TestPlanUserLifecycle pins the status matrix. STAGED→transition is the regression
+// (enable_user used to report already-enabled without touching the account).
+func TestPlanUserLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		enabled    bool
+		oktaStatus string
+		want       lifecyclePlan
+	}{
+		{name: "enable activates a staged account", enabled: true, oktaStatus: userStatusStaged, want: planTransition},
+		{name: "enable unsuspends a suspended account", enabled: true, oktaStatus: userStatusSuspended, want: planTransition},
+		{name: "enable leaves an active account alone", enabled: true, oktaStatus: userStatusActive, want: planAlreadySatisfied},
+		{name: "enable leaves a provisioned account alone", enabled: true, oktaStatus: userStatusProvisioned, want: planAlreadySatisfied},
+		{name: "enable does not clear a recovery state", enabled: true, oktaStatus: userStatusRecovery, want: planAlreadySatisfied},
+		{name: "enable does not clear an expired password", enabled: true, oktaStatus: userStatusPasswordExpired, want: planAlreadySatisfied},
+		{name: "enable does not unlock a locked out account", enabled: true, oktaStatus: userStatusLockedOut, want: planAlreadySatisfied},
+		{name: "enable refuses to reactivate a deactivated account", enabled: true, oktaStatus: userStatusDeprovisioned, want: planUnsupported},
+		{name: "enable refuses an unknown status", enabled: true, oktaStatus: "NOT_A_STATUS", want: planUnsupported},
+
+		{name: "disable suspends an active account", oktaStatus: userStatusActive, want: planTransition},
+		{name: "disable suspends a provisioned account", oktaStatus: userStatusProvisioned, want: planTransition},
+		{name: "disable suspends an account in recovery", oktaStatus: userStatusRecovery, want: planTransition},
+		{name: "disable suspends an account with an expired password", oktaStatus: userStatusPasswordExpired, want: planTransition},
+		{name: "disable suspends a locked out account", oktaStatus: userStatusLockedOut, want: planTransition},
+		{name: "disable leaves a suspended account alone", oktaStatus: userStatusSuspended, want: planAlreadySatisfied},
+		{name: "disable leaves a staged account alone", oktaStatus: userStatusStaged, want: planAlreadySatisfied},
+		{name: "disable leaves a deactivated account alone", oktaStatus: userStatusDeprovisioned, want: planAlreadySatisfied},
+		{name: "disable refuses an unknown status", oktaStatus: "NOT_A_STATUS", want: planUnsupported},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, transition := planUserLifecycle(tt.oktaStatus, tt.enabled)
+			if got != tt.want {
+				t.Fatalf("planUserLifecycle(%s, %t) = %v, want %v", tt.oktaStatus, tt.enabled, got, tt.want)
+			}
+			if (transition != nil) != (tt.want == planTransition) {
+				t.Errorf("planUserLifecycle(%s, %t) returned transition=%v, which does not match plan %v", tt.oktaStatus, tt.enabled, transition != nil, got)
+			}
+		})
+	}
+}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -768,16 +768,6 @@ func (o *userResourceType) Get(ctx context.Context, resourceId *v2.ResourceId, p
 // getUser retrieves the Okta user with the specified ID (may use the SDK GET cache).
 // The request omits credentials and related fields to reduce payload size.
 func getUser(ctx context.Context, client *okta.Client, oktaUserID string) (*okta.User, *responseContext, error) {
-	return fetchUser(ctx, client, oktaUserID, false)
-}
-
-// getUserUncached bypasses the SDK GET cache. Lifecycle POSTs do not invalidate
-// GET /users/{id}, so status reads that decide or report state must not use the cache.
-func getUserUncached(ctx context.Context, client *okta.Client, oktaUserID string) (*okta.User, *responseContext, error) {
-	return fetchUser(ctx, client, oktaUserID, true)
-}
-
-func fetchUser(ctx context.Context, client *okta.Client, oktaUserID string, bypassCache bool) (*okta.User, *responseContext, error) {
 	reqUrl, err := url.Parse(usersUrl)
 	if err != nil {
 		return nil, nil, err
@@ -800,11 +790,6 @@ func fetchUser(ctx context.Context, client *okta.Client, oktaUserID string, bypa
 
 	// Need to set content type here because the response was still including the credentials when setting it with WithContentType above
 	req.Header.Set("Content-Type", `application/json; okta-response="omitCredentials,omitCredentialsLinks,omitTransitioningToStatus"`)
-
-	if bypassCache {
-		// rq is a clone, so RefreshNext cannot leak to other requests.
-		rq = rq.RefreshNext()
-	}
 
 	resp, err := rq.Do(ctx, req, &oktaUsers)
 	if err != nil {
@@ -865,7 +850,7 @@ func unsuspendUser(ctx context.Context, client *okta.Client, oktaUserID string) 
 }
 
 // activateUser activates oktaUserID with sendEmail=false (STAGED → ACTIVE/PROVISIONED).
-// Callers must re-read because the resulting status depends on the account provider and credentials.
+// The ActivateUser response has no User status; callers that need the landing status must GET.
 func activateUser(ctx context.Context, client *okta.Client, oktaUserID string) error {
 	l := ctxzap.Extract(ctx)
 	l.Debug("activating user", zap.String("user_id", oktaUserID))

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -39,7 +39,8 @@ const (
 
 // oktaEnabledStatuses drives enable_user / disable_user only. Credential problems
 // (RECOVERY, PASSWORD_EXPIRED, LOCKED_OUT) stay here — enable does not clear them.
-// Sync still maps STAGED → RESOURCE_STATUS_ENABLED; that contract is unchanged.
+// Sync maps the same "cannot sign in yet / anymore" set to RESOURCE_STATUS_DISABLED
+// (STAGED, SUSPENDED, DEPROVISIONED) so C1 status matches lifecycle actions.
 var oktaEnabledStatuses = []string{
 	userStatusActive,
 	userStatusProvisioned,
@@ -357,9 +358,12 @@ func userResource(user *okta.User, skipSecondaryEmails bool) (*v2.Resource, erro
 	// TODO: change userStatusDeprovisioned to STATUS_DELETED once we show deleted stuff in baton & the UI
 	// case userStatusDeprovisioned:
 	// options = append(options, resource.WithDetailedStatus(v2.UserTrait_Status_STATUS_DELETED, user.Status))
-	case userStatusSuspended, userStatusDeprovisioned:
+	// STAGED is pre-activation in Okta (cannot sign in) — same DISABLED bucket as SUSPENDED /
+	// DEPROVISIONED, aligned with enable_user/disable_user. PROVISIONED stays ENABLED: the
+	// account was activated and is only pending user action (password / email).
+	case userStatusStaged, userStatusSuspended, userStatusDeprovisioned:
 		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_DISABLED, user.Status))
-	case userStatusActive, userStatusProvisioned, userStatusStaged, userStatusPasswordExpired, userStatusRecovery, userStatusLockedOut:
+	case userStatusActive, userStatusProvisioned, userStatusPasswordExpired, userStatusRecovery, userStatusLockedOut:
 		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, user.Status))
 	default:
 		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_UNSPECIFIED, user.Status))

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -354,16 +354,16 @@ func userResource(user *okta.User, skipSecondaryEmails bool) (*v2.Resource, erro
 		options = append(options, resource.WithEmployeeID(employeeIDs.ToSlice()...))
 	}
 
-	switch user.Status {
+	switch {
 	// TODO: change userStatusDeprovisioned to STATUS_DELETED once we show deleted stuff in baton & the UI
 	// case userStatusDeprovisioned:
 	// options = append(options, resource.WithDetailedStatus(v2.UserTrait_Status_STATUS_DELETED, user.Status))
 	// STAGED is pre-activation in Okta (cannot sign in) — same DISABLED bucket as SUSPENDED /
-	// DEPROVISIONED, aligned with enable_user/disable_user. PROVISIONED stays ENABLED: the
-	// account was activated and is only pending user action (password / email).
-	case userStatusStaged, userStatusSuspended, userStatusDeprovisioned:
+	// DEPROVISIONED via isDisabledOktaStatus, aligned with enable_user/disable_user.
+	// PROVISIONED stays ENABLED (isEnabledOktaStatus): activated, pending user action only.
+	case isDisabledOktaStatus(user.Status):
 		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_DISABLED, user.Status))
-	case userStatusActive, userStatusProvisioned, userStatusPasswordExpired, userStatusRecovery, userStatusLockedOut:
+	case isEnabledOktaStatus(user.Status):
 		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, user.Status))
 	default:
 		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_UNSPECIFIED, user.Status))

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -35,6 +36,32 @@ const (
 	userStatusRecovery        = "RECOVERY"
 	userStatusStaged          = "STAGED"
 )
+
+// oktaEnabledStatuses drives enable_user / disable_user only. Credential problems
+// (RECOVERY, PASSWORD_EXPIRED, LOCKED_OUT) stay here — enable does not clear them.
+// Sync still maps STAGED → RESOURCE_STATUS_ENABLED; that contract is unchanged.
+var oktaEnabledStatuses = []string{
+	userStatusActive,
+	userStatusProvisioned,
+	userStatusRecovery,
+	userStatusPasswordExpired,
+	userStatusLockedOut,
+}
+
+// oktaDisabledStatuses: nobody can sign in (never activated, suspended, or deactivated).
+var oktaDisabledStatuses = []string{
+	userStatusStaged,
+	userStatusSuspended,
+	userStatusDeprovisioned,
+}
+
+func isEnabledOktaStatus(oktaStatus string) bool {
+	return slices.Contains(oktaEnabledStatuses, oktaStatus)
+}
+
+func isDisabledOktaStatus(oktaStatus string) bool {
+	return slices.Contains(oktaDisabledStatuses, oktaStatus)
+}
 
 type userResourceType struct {
 	resourceType *v2.ResourceType
@@ -738,10 +765,19 @@ func (o *userResourceType) Get(ctx context.Context, resourceId *v2.ResourceId, p
 	return resource, annos, nil
 }
 
-// getUser retrieves the Okta user with the specified ID.
-// It returns the Okta user and a responseContext containing the HTTP response; if the user is not found or the request fails, an error is returned.
-// The underlying request omits credentials and related fields from the response to reduce payload size.
+// getUser retrieves the Okta user with the specified ID (may use the SDK GET cache).
+// The request omits credentials and related fields to reduce payload size.
 func getUser(ctx context.Context, client *okta.Client, oktaUserID string) (*okta.User, *responseContext, error) {
+	return fetchUser(ctx, client, oktaUserID, false)
+}
+
+// getUserUncached bypasses the SDK GET cache. Lifecycle POSTs do not invalidate
+// GET /users/{id}, so status reads that decide or report state must not use the cache.
+func getUserUncached(ctx context.Context, client *okta.Client, oktaUserID string) (*okta.User, *responseContext, error) {
+	return fetchUser(ctx, client, oktaUserID, true)
+}
+
+func fetchUser(ctx context.Context, client *okta.Client, oktaUserID string, bypassCache bool) (*okta.User, *responseContext, error) {
 	reqUrl, err := url.Parse(usersUrl)
 	if err != nil {
 		return nil, nil, err
@@ -764,6 +800,11 @@ func getUser(ctx context.Context, client *okta.Client, oktaUserID string) (*okta
 
 	// Need to set content type here because the response was still including the credentials when setting it with WithContentType above
 	req.Header.Set("Content-Type", `application/json; okta-response="omitCredentials,omitCredentialsLinks,omitTransitioningToStatus"`)
+
+	if bypassCache {
+		// rq is a clone, so RefreshNext cannot leak to other requests.
+		rq = rq.RefreshNext()
+	}
 
 	resp, err := rq.Do(ctx, req, &oktaUsers)
 	if err != nil {
@@ -820,5 +861,27 @@ func unsuspendUser(ctx context.Context, client *okta.Client, oktaUserID string) 
 	}
 
 	l.Info("user unsuspended", zap.String("user_id", oktaUserID))
+	return nil
+}
+
+// activateUser activates oktaUserID with sendEmail=false (STAGED → ACTIVE/PROVISIONED).
+// Callers must re-read because the resulting status depends on the account provider and credentials.
+func activateUser(ctx context.Context, client *okta.Client, oktaUserID string) error {
+	l := ctxzap.Extract(ctx)
+	l.Debug("activating user", zap.String("user_id", oktaUserID))
+
+	if oktaUserID == "" {
+		return fmt.Errorf("okta-connectorv2: user ID cannot be empty")
+	}
+
+	_, resp, err := client.User.ActivateUser(ctx, oktaUserID, query.NewQueryParams(query.WithSendEmail(false)))
+	if err != nil {
+		return fmt.Errorf("okta-connectorv2: failed to activate user: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("okta-connectorv2: failed to activate user: %s", resp.Status)
+	}
+
+	l.Info("user activated", zap.String("user_id", oktaUserID))
 	return nil
 }

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -56,13 +56,6 @@ func TestUserResource_HasV1Identifier(t *testing.T) {
 func TestUserResource_StatusMapping(t *testing.T) {
 	t.Parallel()
 
-	profile := okta.UserProfile{
-		"firstName": "Test",
-		"lastName":  "User",
-		"email":     "test.user@example.com",
-		"login":     "test.user@example.com",
-	}
-
 	tests := []struct {
 		oktaStatus string
 		want       v2.Status_ResourceStatus
@@ -81,6 +74,14 @@ func TestUserResource_StatusMapping(t *testing.T) {
 		t.Run(tt.oktaStatus, func(t *testing.T) {
 			t.Parallel()
 
+			// Per-subtest profile: userResource mutates the map, so a shared
+			// profile would race under t.Parallel().
+			profile := okta.UserProfile{
+				"firstName": "Test",
+				"lastName":  "User",
+				"email":     "test.user@example.com",
+				"login":     "test.user@example.com",
+			}
 			user := &okta.User{
 				Id:      "00uteststatus",
 				Status:  tt.oktaStatus,

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -53,6 +53,57 @@ func TestUserResource_HasV1Identifier(t *testing.T) {
 	}
 }
 
+func TestUserResource_StatusMapping(t *testing.T) {
+	t.Parallel()
+
+	profile := okta.UserProfile{
+		"firstName": "Test",
+		"lastName":  "User",
+		"email":     "test.user@example.com",
+		"login":     "test.user@example.com",
+	}
+
+	tests := []struct {
+		oktaStatus string
+		want       v2.Status_ResourceStatus
+	}{
+		{oktaStatus: userStatusStaged, want: v2.Status_RESOURCE_STATUS_DISABLED},
+		{oktaStatus: userStatusSuspended, want: v2.Status_RESOURCE_STATUS_DISABLED},
+		{oktaStatus: userStatusDeprovisioned, want: v2.Status_RESOURCE_STATUS_DISABLED},
+		{oktaStatus: userStatusActive, want: v2.Status_RESOURCE_STATUS_ENABLED},
+		{oktaStatus: userStatusProvisioned, want: v2.Status_RESOURCE_STATUS_ENABLED},
+		{oktaStatus: userStatusRecovery, want: v2.Status_RESOURCE_STATUS_ENABLED},
+		{oktaStatus: userStatusPasswordExpired, want: v2.Status_RESOURCE_STATUS_ENABLED},
+		{oktaStatus: userStatusLockedOut, want: v2.Status_RESOURCE_STATUS_ENABLED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.oktaStatus, func(t *testing.T) {
+			t.Parallel()
+
+			user := &okta.User{
+				Id:      "00uteststatus",
+				Status:  tt.oktaStatus,
+				Profile: &profile,
+			}
+			got, err := userResource(user, false)
+			if err != nil {
+				t.Fatalf("userResource: %v", err)
+			}
+			status := got.GetStatus()
+			if status == nil {
+				t.Fatal("user resource missing status")
+			}
+			if status.GetStatus() != tt.want {
+				t.Fatalf("status = %v, want %v (details %q)", status.GetStatus(), tt.want, status.GetDetails())
+			}
+			if status.GetDetails() != tt.oktaStatus {
+				t.Fatalf("status details = %q, want Okta status %q", status.GetDetails(), tt.oktaStatus)
+			}
+		})
+	}
+}
+
 func Test_shouldIncludeUserByEmails(t *testing.T) {
 	type args struct {
 		userEmails         []string


### PR DESCRIPTION
## Description
- [x] Bug fix
- [ ] New feature

CXH-2223 fixes Okta lifecycle actions that could report success without reaching the requested account state. `enable_user` now activates `STAGED` users without sending email, continues to unsuspend `SUSPENDED` users, and plans transitions from live Okta status. `disable_user` uses the same status-aware path and no longer relies on matching Okta error strings.

The duplicate-account behavior from CXH-2201 remains unchanged: a repeated create returns the existing account without using the ambiguous `STAGED` state as proof that the connector created it. Operators can now explicitly recover a stranded staged account through `enable_user`.

This PR also aligns sync with Okta: `STAGED` users sync as `RESOURCE_STATUS_DISABLED` (they cannot sign in until activated), matching lifecycle actions and the create-inactive wording.

### Sync:

- **Users** (`user`) — **sync status change:** `STAGED` maps to `RESOURCE_STATUS_DISABLED` (was `ENABLED`). `PROVISIONED` stays enabled. Details still carry the raw Okta status string.
- **Groups** (`group`) — unchanged.
- **Roles** (`role`) — unchanged.

### Provisioning:

- **Create/Delete user accounts** — repeated create keeps the existing account unchanged; `enable_user` is the explicit recovery path for a stranded `STAGED` account.
- **Lifecycle actions** — `enable_user` and `disable_user` inspect Okta status, perform only supported transitions, and trust a successful lifecycle call (no post-mutation confirm GET / no action-local SDK cache bypass).
- **Grant/Revoke group membership** — unchanged; existing `GrantAlreadyExists` and `GrantAlreadyRevoked` idempotency behavior remains intact.
- **Grant/Revoke role assignment** — unchanged.

### Auth:

API-token and OAuth private-key authentication are unchanged.

### Architecture highlights:

- One shared status-aware runner for symmetric enable/disable behavior (`applyUserLifecycle`).
- Sync and actions share the same enabled/disabled Okta status predicates so the two cannot drift.
- Rejects unsupported transitions with `FailedPrecondition` (including `enable_user` on `DEPROVISIONED`).

### Behavior notes (externally visible):

1. **`enable_user` on `DEPROVISIONED`** previously returned success via the string-matched unsuspend swallow. It now returns `FailedPrecondition`. The old success was a false report; `docs/connector.mdx` documents the new contract.
2. **`STAGED` sync status** flips from enabled → disabled on the next sync after upgrade. Review automations that key off user enabled/disabled status. Documented in `docs/connector.mdx` and `docs/docs-info.md`.

### Useful links:

- [Linear ticket CXH-2223 — recover stranded staged accounts and remove false lifecycle successes](https://linear.app/ductone/issue/CXH-2223)
- [Okta Users API — lifecycle operations](https://developer.okta.com/docs/reference/api/users/#lifecycle-operations)
- [Okta user account statuses](https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-end-user-states.htm)
