### PR TITLE
[CXH-2224] - Normalize Okta domain URL configuration - Okta Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Flags:
       --cache-ttl int                                    Response cache time to live in seconds ($BATON_CACHE_TTL) (default 300)
       --client-id string                                 The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
       --client-secret string                             The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
-      --domain string                                    required: The URL for the Okta organization ($BATON_DOMAIN)
+      --domain string                                    required: Okta organization hostname, optionally prefixed with https:// ($BATON_DOMAIN)
       --external-resource-c1z string                     The path to the c1z file to sync external baton resources with ($BATON_EXTERNAL_RESOURCE_C1Z)
       --external-resource-entitlement-id-filter string   The entitlement that external users, groups must have access to sync external baton resources ($BATON_EXTERNAL_RESOURCE_ENTITLEMENT_ID_FILTER)
   -f, --file string                                      The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")

--- a/config_schema.json
+++ b/config_schema.json
@@ -95,7 +95,7 @@
     {
       "name": "domain",
       "displayName": "Okta domain",
-      "description": "The URL for the Okta organization",
+      "description": "Okta organization hostname, optionally prefixed with https://",
       "placeholder": "e.g. acmeco.okta.com",
       "isRequired": true,
       "stringField": {

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -368,7 +368,7 @@ Find the **Settings** area of the page and click **Edit**.
 Select your authentication method: **API Token** or **OAuth 2.0 Private Key**.
 </Step>
 <Step>
-Enter your Okta domain (the URL of your Okta instance is `<YOUR DOMAIN>.okta.com`) into the **Okta domain** field.
+Enter your Okta domain hostname, e.g. `<YOUR DOMAIN>.okta.com`, into the **Okta domain** field. The `https://` prefix is optional.
 </Step>
 <Step>
 Enter your credentials:

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -34,7 +34,7 @@ Internal technical notes for maintainers. Customer-facing setup lives in [`docs/
 ## Connector credentials
 
 1. What credentials are needed?
-   - **Domain** (`--domain` / `$BATON_DOMAIN`) — Okta org host, e.g. `acmeco.okta.com` or `integrator-123.okta.com`. A value that includes `https://` (or a trailing slash) is normalised to the hostname before the client is built.
+   - **Domain** (`--domain` / `$BATON_DOMAIN`) — Okta org host, e.g. `acmeco.okta.com` or `integrator-123.okta.com`. A value that includes `https://` (or a trailing slash) is normalised before the client is built; an explicit port is preserved (e.g. local mocks). Path, query, fragment, and userinfo are rejected.
    - **API Token** (`--api-token` / `$BATON_API_TOKEN`) — SSWS token, **or**
    - **OAuth private key** — `--auth-method=private-key-group` plus `--okta-client-id`, `--okta-private-key-id`, `--okta-private-key` (PEM-encoded RSA key; PKCS#1 or PKCS#8, see [OAuth private key handling](#oauth-private-key-handling))
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -34,7 +34,7 @@ Internal technical notes for maintainers. Customer-facing setup lives in [`docs/
 ## Connector credentials
 
 1. What credentials are needed?
-   - **Domain** (`--domain` / `$BATON_DOMAIN`) — Okta org host, e.g. `acmeco.okta.com` or `integrator-123.okta.com`
+   - **Domain** (`--domain` / `$BATON_DOMAIN`) — Okta org host, e.g. `acmeco.okta.com` or `integrator-123.okta.com`. A value that includes `https://` (or a trailing slash) is normalised to the hostname before the client is built.
    - **API Token** (`--api-token` / `$BATON_API_TOKEN`) — SSWS token, **or**
    - **OAuth private key** — `--auth-method=private-key-group` plus `--okta-client-id`, `--okta-private-key-id`, `--okta-private-key` (PEM-encoded RSA key; PKCS#1 or PKCS#8, see [OAuth private key handling](#oauth-private-key-handling))
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,7 @@ var (
 	domain = field.StringField("domain",
 		field.WithDisplayName("Okta domain"),
 		field.WithRequired(true),
-		field.WithDescription("The URL for the Okta organization"),
+		field.WithDescription("Okta organization hostname, optionally prefixed with https://"),
 		field.WithPlaceholder("e.g. acmeco.okta.com"),
 	)
 	apiToken = field.StringField("api-token",

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"strings"
 
 	cfg "github.com/conductorone/baton-okta/pkg/config"
@@ -26,6 +27,8 @@ import (
 // TODO: use isNotFoundError() since E0000008 is also a not found error
 const ResourceNotFoundExceptionErrorCode = "E0000007"
 const AccessDeniedErrorCode = "E0000006"
+
+const oktaURLScheme = "https"
 
 // oktaSDKAuthSentinel activates the SDK's Bearer auth path; the oktaauth RoundTripper substitutes the real DPoP/Bearer token per request.
 const oktaSDKAuthSentinel = "dpop-managed"
@@ -353,11 +356,43 @@ func safeCacheInt32(val int) (int32, error) {
 	return int32(val), nil
 }
 
+// parseOktaOrgURL returns a canonical HTTPS URL for the configured Okta domain.
+func parseOktaOrgURL(raw string) (*url.URL, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("okta-connectorv2: domain is required")
+	}
+
+	toParse := raw
+	if !strings.Contains(raw, "://") {
+		toParse = (&url.URL{Scheme: oktaURLScheme, Host: strings.TrimSuffix(raw, "/")}).String()
+	}
+	parsed, err := url.Parse(toParse)
+	if err != nil {
+		return nil, fmt.Errorf("okta-connectorv2: domain must be an HTTPS hostname (e.g. acmeco.okta.com), got %q: %w", raw, err)
+	}
+	if parsed.Scheme != oktaURLScheme || parsed.Hostname() == "" ||
+		parsed.User != nil || parsed.Port() != "" ||
+		(parsed.Path != "" && parsed.Path != "/") ||
+		parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("okta-connectorv2: domain must be an HTTPS hostname (e.g. acmeco.okta.com), got %q", raw)
+	}
+
+	return &url.URL{Scheme: oktaURLScheme, Host: parsed.Hostname()}, nil
+}
+
 func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	var (
 		oktaClient *okta.Client
 		scopes     = defaultScopes
 	)
+
+	orgURL, err := parseOktaOrgURL(cc.Domain)
+	if err != nil {
+		return nil, nil, err
+	}
+	domain := orgURL.Hostname()
+
 	client, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, nil))
 	if err != nil {
 		return nil, nil, err
@@ -385,7 +420,7 @@ func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorb
 		fallthrough
 	case cfg.ApiTokenGroup:
 		_, oktaClient, err = okta.NewClient(ctx,
-			okta.WithOrgUrl(fmt.Sprintf("https://%s", cc.Domain)),
+			okta.WithOrgUrl(orgURL.String()),
 			okta.WithToken(cc.ApiToken),
 			okta.WithHttpClientPtr(client),
 			okta.WithCache(cc.Cache),
@@ -397,7 +432,7 @@ func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorb
 		}
 
 		config, err := oktav5.NewConfiguration(
-			oktav5.WithOrgUrl(fmt.Sprintf("https://%s", cc.Domain)),
+			oktav5.WithOrgUrl(orgURL.String()),
 			oktav5.WithToken(cc.ApiToken),
 			oktav5.WithHttpClientPtr(client),
 			oktav5.WithCache(cc.Cache),
@@ -422,7 +457,7 @@ func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorb
 		}
 
 		dpopClient, err := oktaauth.NewDPoPHTTPClient(ctx, oktaauth.Config{
-			Domain:        cc.Domain,
+			Domain:        domain,
 			ClientID:      cc.OktaClientId,
 			PrivateKeyPEM: cc.OktaPrivateKey,
 			PrivateKeyID:  cc.OktaPrivateKeyId,
@@ -434,7 +469,7 @@ func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorb
 
 		// Bearer mode lets the oktaauth transport own auth; bypasses v5's native PrivateKey/DPoP path.
 		_, oktaClient, err = okta.NewClient(ctx,
-			okta.WithOrgUrl(fmt.Sprintf("https://%s", cc.Domain)),
+			okta.WithOrgUrl(orgURL.String()),
 			okta.WithAuthorizationMode("Bearer"),
 			okta.WithToken(oktaSDKAuthSentinel),
 			okta.WithHttpClientPtr(dpopClient),
@@ -447,7 +482,7 @@ func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorb
 		}
 
 		config, err := oktav5.NewConfiguration(
-			oktav5.WithOrgUrl(fmt.Sprintf("https://%s", cc.Domain)),
+			oktav5.WithOrgUrl(orgURL.String()),
 			oktav5.WithAuthorizationMode("Bearer"),
 			oktav5.WithToken(oktaSDKAuthSentinel),
 			oktav5.WithHttpClientPtr(dpopClient),
@@ -465,7 +500,7 @@ func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorb
 	return &Okta{
 		client:              oktaClient,
 		clientV5:            oktaClientV5,
-		domain:              cc.Domain,
+		domain:              domain,
 		apiToken:            cc.ApiToken,
 		syncInactiveApps:    cc.SyncInactiveApps,
 		SyncCustomRoles:     cc.SyncCustomRoles,

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -216,7 +216,7 @@ func (c *Okta) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 
 	var annos annotations.Annotations
 	annos.Update(&v2.ExternalLink{
-		Url: c.domain,
+		Url: (&url.URL{Scheme: oktaURLScheme, Host: c.domain}).String(),
 	})
 
 	return &v2.ConnectorMetadata{
@@ -357,6 +357,7 @@ func safeCacheInt32(val int) (int32, error) {
 }
 
 // parseOktaOrgURL returns a canonical HTTPS URL for the configured Okta domain.
+// An explicit port is preserved (e.g. local mocks); path, query, fragment, and userinfo are rejected.
 func parseOktaOrgURL(raw string) (*url.URL, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -372,13 +373,13 @@ func parseOktaOrgURL(raw string) (*url.URL, error) {
 		return nil, fmt.Errorf("okta-connectorv2: domain must be an HTTPS hostname (e.g. acmeco.okta.com), got %q: %w", raw, err)
 	}
 	if parsed.Scheme != oktaURLScheme || parsed.Hostname() == "" ||
-		parsed.User != nil || parsed.Port() != "" ||
+		parsed.User != nil ||
 		(parsed.Path != "" && parsed.Path != "/") ||
 		parsed.RawQuery != "" || parsed.Fragment != "" {
 		return nil, fmt.Errorf("okta-connectorv2: domain must be an HTTPS hostname (e.g. acmeco.okta.com), got %q", raw)
 	}
 
-	return &url.URL{Scheme: oktaURLScheme, Host: parsed.Hostname()}, nil
+	return &url.URL{Scheme: oktaURLScheme, Host: parsed.Host}, nil
 }
 
 func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
@@ -391,7 +392,8 @@ func New(ctx context.Context, cc *cfg.Okta, opts *cli.ConnectorOpts) (connectorb
 	if err != nil {
 		return nil, nil, err
 	}
-	domain := orgURL.Hostname()
+	// Host keeps an explicit port when present (Hostname() would drop it).
+	domain := orgURL.Host
 
 	client, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, nil))
 	if err != nil {

--- a/pkg/connector/domain_test.go
+++ b/pkg/connector/domain_test.go
@@ -1,0 +1,61 @@
+package connector
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseOktaOrgURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr string
+	}{
+		{name: "bare host", raw: "acmeco.okta.com", want: "https://acmeco.okta.com"},
+		{name: "https scheme", raw: "https://acmeco.okta.com", want: "https://acmeco.okta.com"},
+		{name: "https with trailing slash", raw: "https://acmeco.okta.com/", want: "https://acmeco.okta.com"},
+		{name: "bare host with trailing slash", raw: "acmeco.okta.com/", want: "https://acmeco.okta.com"},
+		{name: "whitespace", raw: "  acmeco.okta.com  ", want: "https://acmeco.okta.com"},
+		{name: "empty", raw: "", wantErr: "domain is required"},
+		{name: "whitespace only", raw: "   ", wantErr: "domain is required"},
+		{name: "scheme only", raw: "https://", wantErr: "domain must be an HTTPS hostname"},
+		{name: "http scheme", raw: "http://acmeco.okta.com", wantErr: "domain must be an HTTPS hostname"},
+		{name: "path", raw: "https://acmeco.okta.com/admin", wantErr: "domain must be an HTTPS hostname"},
+		{name: "bare path", raw: "acmeco.okta.com/admin", wantErr: "domain must be an HTTPS hostname"},
+		{name: "query", raw: "https://acmeco.okta.com?redirect=evil.example", wantErr: "domain must be an HTTPS hostname"},
+		{name: "fragment", raw: "https://acmeco.okta.com#fragment", wantErr: "domain must be an HTTPS hostname"},
+		{name: "userinfo", raw: "https://user@acmeco.okta.com", wantErr: "domain must be an HTTPS hostname"},
+		{name: "port", raw: "https://acmeco.okta.com:8443", wantErr: "domain must be an HTTPS hostname"},
+		{name: "double scheme", raw: "https://https://acmeco.okta.com", wantErr: "domain must be an HTTPS hostname"},
+		{name: "garbage", raw: "://", wantErr: "domain must be an HTTPS hostname"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseOktaOrgURL(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseOktaOrgURL(%q) = %q, want error containing %q", tt.raw, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), "domain") {
+					t.Fatalf("error must name the domain field, got %q", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOktaOrgURL(%q): %v", tt.raw, err)
+			}
+			if got.String() != tt.want {
+				t.Fatalf("parseOktaOrgURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/connector/domain_test.go
+++ b/pkg/connector/domain_test.go
@@ -28,7 +28,8 @@ func TestParseOktaOrgURL(t *testing.T) {
 		{name: "query", raw: "https://acmeco.okta.com?redirect=evil.example", wantErr: "domain must be an HTTPS hostname"},
 		{name: "fragment", raw: "https://acmeco.okta.com#fragment", wantErr: "domain must be an HTTPS hostname"},
 		{name: "userinfo", raw: "https://user@acmeco.okta.com", wantErr: "domain must be an HTTPS hostname"},
-		{name: "port", raw: "https://acmeco.okta.com:8443", wantErr: "domain must be an HTTPS hostname"},
+		{name: "https with port", raw: "https://acmeco.okta.com:8443", want: "https://acmeco.okta.com:8443"},
+		{name: "bare host with port", raw: "acmeco.okta.com:8443", want: "https://acmeco.okta.com:8443"},
 		{name: "double scheme", raw: "https://https://acmeco.okta.com", wantErr: "domain must be an HTTPS hostname"},
 		{name: "garbage", raw: "://", wantErr: "domain must be an HTTPS hostname"},
 	}

--- a/pkg/oktaauth/oktaauth.go
+++ b/pkg/oktaauth/oktaauth.go
@@ -73,7 +73,9 @@ func NewDPoPHTTPClient(ctx context.Context, cfg Config, baseClient *http.Client)
 		return nil, fmt.Errorf("oktaauth: build dpop proofer: %w", err)
 	}
 
-	orgURL := (&url.URL{Scheme: "https", Host: cfg.Domain}).String()
+	// Trim a trailing slash so a Domain of "example.okta.com/" does not become
+	// Host "example.okta.com/" → percent-escaped "example.okta.com%2F" in String().
+	orgURL := (&url.URL{Scheme: "https", Host: strings.TrimSuffix(cfg.Domain, "/")}).String()
 	tokenURL, err := url.JoinPath(orgURL, tokenPath)
 	if err != nil {
 		return nil, fmt.Errorf("oktaauth: build token URL: %w", err)

--- a/pkg/oktaauth/oktaauth.go
+++ b/pkg/oktaauth/oktaauth.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -72,7 +73,11 @@ func NewDPoPHTTPClient(ctx context.Context, cfg Config, baseClient *http.Client)
 		return nil, fmt.Errorf("oktaauth: build dpop proofer: %w", err)
 	}
 
-	tokenURL := fmt.Sprintf("https://%s%s", strings.TrimSuffix(cfg.Domain, "/"), tokenPath)
+	orgURL := (&url.URL{Scheme: "https", Host: cfg.Domain}).String()
+	tokenURL, err := url.JoinPath(orgURL, tokenPath)
+	if err != nil {
+		return nil, fmt.Errorf("oktaauth: build token URL: %w", err)
+	}
 
 	tokenNonceStore := dpop_oauth2.NewNonceStore()
 	resourceNonceStore := dpop_oauth2.NewNonceStore()

--- a/pkg/oktaauth/oktaauth_test.go
+++ b/pkg/oktaauth/oktaauth_test.go
@@ -209,6 +209,32 @@ func TestTokenSource_RejectsNonRSA(t *testing.T) {
 	}
 }
 
+func TestNewDPoPHTTPClient_BuildsTokenURL(t *testing.T) {
+	key := generateRSAKey(t)
+	client, err := NewDPoPHTTPClient(t.Context(), Config{
+		Domain:        "example.okta.com",
+		ClientID:      "c",
+		PrivateKeyID:  "k",
+		PrivateKeyPEM: pemPKCS8(t, key),
+		Scopes:        []string{"okta.users.read"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewDPoPHTTPClient: %v", err)
+	}
+
+	transport, ok := client.Transport.(*dpopRoundTripper)
+	if !ok {
+		t.Fatalf("transport type = %T, want *dpopRoundTripper", client.Transport)
+	}
+	tokenSource, ok := transport.tokenSource.(*tokenSource)
+	if !ok {
+		t.Fatalf("token source type = %T, want *tokenSource", transport.tokenSource)
+	}
+	if got, want := tokenSource.cfg.tokenURL, "https://example.okta.com/oauth2/v1/token"; got != want {
+		t.Fatalf("token URL = %q, want %q", got, want)
+	}
+}
+
 func TestTokenSource_BearerTokenAccepted(t *testing.T) {
 	key := generateRSAKey(t)
 	h := &tokenHandler{tokenType: "Bearer"}
@@ -317,10 +343,10 @@ func TestParseRSAPrivateKey(t *testing.T) {
 	ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 
 	cases := []struct {
-		name      string
-		pem       string
-		wantErr   string
-		wantOK    bool
+		name    string
+		pem     string
+		wantErr string
+		wantOK  bool
 	}{
 		{name: "PKCS1", pem: pemPKCS1(t, rsaKey), wantOK: true},
 		{name: "PKCS1_literal_newlines", pem: strings.ReplaceAll(pemPKCS1(t, rsaKey), "\n", `\n`), wantOK: true},

--- a/pkg/oktaauth/oktaauth_test.go
+++ b/pkg/oktaauth/oktaauth_test.go
@@ -210,28 +210,45 @@ func TestTokenSource_RejectsNonRSA(t *testing.T) {
 }
 
 func TestNewDPoPHTTPClient_BuildsTokenURL(t *testing.T) {
+	t.Parallel()
 	key := generateRSAKey(t)
-	client, err := NewDPoPHTTPClient(t.Context(), Config{
-		Domain:        "example.okta.com",
-		ClientID:      "c",
-		PrivateKeyID:  "k",
-		PrivateKeyPEM: pemPKCS8(t, key),
-		Scopes:        []string{"okta.users.read"},
-	}, nil)
-	if err != nil {
-		t.Fatalf("NewDPoPHTTPClient: %v", err)
+
+	tests := []struct {
+		name   string
+		domain string
+		want   string
+	}{
+		{name: "bare host", domain: "example.okta.com", want: "https://example.okta.com/oauth2/v1/token"},
+		{name: "trailing slash", domain: "example.okta.com/", want: "https://example.okta.com/oauth2/v1/token"},
+		{name: "host with port", domain: "example.okta.com:8443", want: "https://example.okta.com:8443/oauth2/v1/token"},
 	}
 
-	transport, ok := client.Transport.(*dpopRoundTripper)
-	if !ok {
-		t.Fatalf("transport type = %T, want *dpopRoundTripper", client.Transport)
-	}
-	tokenSource, ok := transport.tokenSource.(*tokenSource)
-	if !ok {
-		t.Fatalf("token source type = %T, want *tokenSource", transport.tokenSource)
-	}
-	if got, want := tokenSource.cfg.tokenURL, "https://example.okta.com/oauth2/v1/token"; got != want {
-		t.Fatalf("token URL = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client, err := NewDPoPHTTPClient(t.Context(), Config{
+				Domain:        tt.domain,
+				ClientID:      "c",
+				PrivateKeyID:  "k",
+				PrivateKeyPEM: pemPKCS8(t, key),
+				Scopes:        []string{"okta.users.read"},
+			}, nil)
+			if err != nil {
+				t.Fatalf("NewDPoPHTTPClient: %v", err)
+			}
+
+			transport, ok := client.Transport.(*dpopRoundTripper)
+			if !ok {
+				t.Fatalf("transport type = %T, want *dpopRoundTripper", client.Transport)
+			}
+			tokenSource, ok := transport.tokenSource.(*tokenSource)
+			if !ok {
+				t.Fatalf("token source type = %T, want *tokenSource", transport.tokenSource)
+			}
+			if got := tokenSource.cfg.tokenURL; got != tt.want {
+				t.Fatalf("token URL = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description
- [x] Bug fix
- [ ] New feature

CXH-2224 fixes Okta domain configuration when an operator supplies the documented URL form. The connector now accepts either `acmeco.okta.com` or `https://acmeco.okta.com/`, builds one canonical HTTPS org URL, and returns a domain-specific validation error for unsupported URL components.

### Sync:

- **Users** (`user`) — unchanged sync surface; client initialization now receives the canonical Okta org URL.
- **Groups** (`group`) — unchanged.
- **Roles** (`role`) — unchanged.

### Provisioning:

- **Create/Delete user accounts** — unchanged.
- **Grant/Revoke group membership** — unchanged; existing `GrantAlreadyExists` and `GrantAlreadyRevoked` idempotency behavior remains intact.
- **Grant/Revoke role assignment** — unchanged.

### Auth:

API-token and OAuth private-key authentication continue to use HTTPS. The existing `--domain` (`BATON_DOMAIN`) field now accepts a bare hostname or an `https://` URL with an optional trailing slash; no new configuration is required.

### Architecture highlights:

- Parses and validates the configured domain with `net/url`.
- Rejects HTTP, userinfo, paths, queries, and fragments instead of forwarding malformed values to the SDK. An explicit port is preserved (e.g. local mocks).
- Uses the canonical URL for both Okta SDK clients and only the validated hostname for DPoP.
- Builds the OAuth token endpoint with `url.JoinPath`.

### Useful links:

- [Linear ticket CXH-2224 — normalize Okta domain URL input](https://linear.app/ductone/issue/CXH-2224)
- [Okta OAuth 2.0 and OpenID Connect endpoints](https://developer.okta.com/docs/reference/api/oidc/)